### PR TITLE
Add a numerical user ID system, add CM commands, add document commands, add area locking (and spectating)

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -169,6 +169,8 @@ class AOClient : public QObject {
     // Areas
     void cmdCM(int argc, QStringList argv);
     void cmdUnCM(int argc, QStringList argv);
+    void cmdInvite(int argc, QStringList argv);
+    void cmdUnInvite(int argc, QStringList argv);
     void cmdGetAreas(int argc, QStringList argv);
     void cmdGetArea(int argc, QStringList argv);
     void cmdSetBackground(int argc, QStringList argv);
@@ -224,7 +226,9 @@ class AOClient : public QObject {
         {"doc", {ACLFlags.value("NONE"), 0, &AOClient::cmdDoc}},
         {"cleardoc", {ACLFlags.value("NONE"), 0, &AOClient::cmdClearDoc}},
         {"cm", {ACLFlags.value("NONE"), 0, &AOClient::cmdCM}},
-        {"uncm", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnCM}}
+        {"uncm", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnCM}},
+        {"invite", {ACLFlags.value("NONE"), 0, &AOClient::cmdInvite}},
+        {"uninvite", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnInvite}}
     };
 
     QString partial_packet;

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -171,6 +171,9 @@ class AOClient : public QObject {
     void cmdUnCM(int argc, QStringList argv);
     void cmdInvite(int argc, QStringList argv);
     void cmdUnInvite(int argc, QStringList argv);
+    void cmdLock(int argc, QStringList argv);
+    void cmdSpectatable(int argc, QStringList argv);
+    void cmdUnLock(int argc, QStringList argv);
     void cmdGetAreas(int argc, QStringList argv);
     void cmdGetArea(int argc, QStringList argv);
     void cmdSetBackground(int argc, QStringList argv);
@@ -227,8 +230,12 @@ class AOClient : public QObject {
         {"cleardoc", {ACLFlags.value("NONE"), 0, &AOClient::cmdClearDoc}},
         {"cm", {ACLFlags.value("NONE"), 0, &AOClient::cmdCM}},
         {"uncm", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnCM}},
-        {"invite", {ACLFlags.value("NONE"), 0, &AOClient::cmdInvite}},
-        {"uninvite", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnInvite}}
+        {"invite", {ACLFlags.value("NONE"), 1, &AOClient::cmdInvite}},
+        {"uninvite", {ACLFlags.value("NONE"), 1, &AOClient::cmdUnInvite}},
+        {"lock", {ACLFlags.value("NONE"), 0, &AOClient::cmdLock}},
+        {"spectatable", {ACLFlags.value("NONE"), 0, &AOClient::cmdSpectatable}},
+        {"unlock", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnLock}},
+
     };
 
     QString partial_packet;

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -90,6 +90,8 @@ class AOClient : public QObject {
     void arup(ARUPType type, bool broadcast);
     void fullArup();
     void sendServerMessage(QString message);
+    void sendServerMessageArea(QString message);
+    void sendServerBroadcast(QString message);
     bool checkAuth(unsigned long long acl_mask);
 
     // Packet headers

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -63,6 +63,7 @@ class AOClient : public QObject {
         {"BAN", 1ULL << 1},
         {"BGLOCK", 1ULL << 2},
         {"MODIFY_USERS", 1ULL << 3},
+        {"CM", 1ULL << 4},
         {"SUPER", ~0ULL}
     };
 
@@ -231,12 +232,12 @@ class AOClient : public QObject {
         {"doc", {ACLFlags.value("NONE"), 0, &AOClient::cmdDoc}},
         {"cleardoc", {ACLFlags.value("NONE"), 0, &AOClient::cmdClearDoc}},
         {"cm", {ACLFlags.value("NONE"), 0, &AOClient::cmdCM}},
-        {"uncm", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnCM}},
-        {"invite", {ACLFlags.value("NONE"), 1, &AOClient::cmdInvite}},
-        {"uninvite", {ACLFlags.value("NONE"), 1, &AOClient::cmdUnInvite}},
-        {"lock", {ACLFlags.value("NONE"), 0, &AOClient::cmdLock}},
-        {"spectatable", {ACLFlags.value("NONE"), 0, &AOClient::cmdSpectatable}},
-        {"unlock", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnLock}},
+        {"uncm", {ACLFlags.value("CM"), 0, &AOClient::cmdUnCM}},
+        {"invite", {ACLFlags.value("CM"), 1, &AOClient::cmdInvite}},
+        {"uninvite", {ACLFlags.value("CM"), 1, &AOClient::cmdUnInvite}},
+        {"lock", {ACLFlags.value("CM"), 0, &AOClient::cmdLock}},
+        {"spectatable", {ACLFlags.value("CM"), 0, &AOClient::cmdSpectatable}},
+        {"unlock", {ACLFlags.value("CM"), 0, &AOClient::cmdUnLock}},
 
     };
 

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -38,13 +38,15 @@ class Server;
 class AOClient : public QObject {
     Q_OBJECT
   public:
-    AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent = nullptr);
+    AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent = nullptr, int user_id = 0);
     ~AOClient();
 
     QString getHwid();
     QString getIpid();
     Server* getServer();
     void setHwid(QString p_hwid);
+
+    int id;
 
     QHostAddress remote_ip;
     QString password;
@@ -152,28 +154,37 @@ class AOClient : public QObject {
         {"EE", {ACLFlags.value("NONE"), 4, &AOClient::pktEditEvidence}}
     };
 
-    // Commands
+    //// Commands
     void cmdDefault(int argc, QStringList argv);
+    // Authentication
     void cmdLogin(int argc, QStringList argv);
-    void cmdGetAreas(int argc, QStringList argv);
-    void cmdGetArea(int argc, QStringList argv);
-    void cmdBan(int argc, QStringList argv);
-    void cmdKick(int argc, QStringList argv);
     void cmdChangeAuth(int argc, QStringList argv);
     void cmdSetRootPass(int argc, QStringList argv);
-    void cmdSetBackground(int argc, QStringList argv);
-    void cmdBgLock(int argc, QStringList argv);
-    void cmdBgUnlock(int argc, QStringList argv);
     void cmdAddUser(int argc, QStringList argv);
     void cmdListPerms(int argc, QStringList argv);
     void cmdAddPerms(int argc, QStringList argv);
     void cmdRemovePerms(int argc, QStringList argv);
     void cmdListUsers(int argc, QStringList argv);
     void cmdLogout(int argc, QStringList argv);
-    void cmdPos(int argc, QStringList argv);
-    void cmdG(int argc, QStringList argv);
+    // Areas
+    void cmdCM(int argc, QStringList argv);
+    void cmdUnCM(int argc, QStringList argv);
+    void cmdGetAreas(int argc, QStringList argv);
+    void cmdGetArea(int argc, QStringList argv);
+    void cmdSetBackground(int argc, QStringList argv);
+    void cmdBgLock(int argc, QStringList argv);
+    void cmdBgUnlock(int argc, QStringList argv);
+    // Moderation
+    void cmdBan(int argc, QStringList argv);
+    void cmdKick(int argc, QStringList argv);
+    // Casing/RP
     void cmdNeed(int argc, QStringList argv);
     void cmdFlip(int argc, QStringList argv);
+    void cmdDoc(int argc, QStringList argv);
+    void cmdClearDoc(int argc, QStringList argv);
+    // Messaging/Client
+    void cmdPos(int argc, QStringList argv);
+    void cmdG(int argc, QStringList argv);
 
     // Command helper functions
     QStringList buildAreaList(int area_idx);
@@ -209,7 +220,11 @@ class AOClient : public QObject {
         {"pos", {ACLFlags.value("NONE"), 1, &AOClient::cmdPos}},
         {"g", {ACLFlags.value("NONE"), 1, &AOClient::cmdG}},
         {"need", {ACLFlags.value("NONE"), 1, &AOClient::cmdNeed}},
-        {"flip", {ACLFlags.value("NONE"), 0, &AOClient::cmdFlip}}
+        {"flip", {ACLFlags.value("NONE"), 0, &AOClient::cmdFlip}},
+        {"doc", {ACLFlags.value("NONE"), 0, &AOClient::cmdDoc}},
+        {"cleardoc", {ACLFlags.value("NONE"), 0, &AOClient::cmdClearDoc}},
+        {"cm", {ACLFlags.value("NONE"), 0, &AOClient::cmdCM}},
+        {"uncm", {ACLFlags.value("NONE"), 0, &AOClient::cmdUnCM}}
     };
 
     QString partial_packet;

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -42,13 +42,19 @@ class AreaData {
     QList<Evidence> evidence;
     int player_count;
     QString status;
-    QString current_cm;
-    bool locked;
+    QList<int> owners;
+    enum LockStatus {
+      FREE,
+      LOCKED,
+      SPECTATABLE
+    };
+    LockStatus locked;
     QString background;
     bool showname_allowed;
     bool locking_allowed;
     bool iniswap_allowed;
     bool bg_locked;
+    QString document;
     int def_hp;
     int pro_hp;
     Logger* logger;

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -51,8 +51,8 @@ class AreaData {
     };
     LockStatus locked;
     QString background;
+    bool is_protected;
     bool showname_allowed;
-    bool locking_allowed;
     bool iniswap_allowed;
     bool bg_locked;
     QString document;

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -43,6 +43,7 @@ class AreaData {
     int player_count;
     QString status;
     QList<int> owners;
+    QList<int> invited;
     enum LockStatus {
       FREE,
       LOCKED,

--- a/include/server.h
+++ b/include/server.h
@@ -50,6 +50,7 @@ class Server : public QObject {
     void updateCharsTaken(AreaData* area);
     void broadcast(AOPacket packet, int area_index);
     void broadcast(AOPacket packet);
+    QString getServerName();
 
     QVector<AOClient*> clients;
 
@@ -60,6 +61,7 @@ class Server : public QObject {
     QStringList music_list;
     QStringList backgrounds;
     DBManager* db_manager;
+    QString server_name;
 
   signals:
 

--- a/include/server.h
+++ b/include/server.h
@@ -46,6 +46,7 @@ class Server : public QObject {
 
     void start();
     AOClient* getClient(QString ipid);
+    AOClient* getClientByID(int id);
     void updateCharsTaken(AreaData* area);
     void broadcast(AOPacket packet, int area_index);
     void broadcast(AOPacket packet);

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -103,7 +103,7 @@ void AOClient::changeArea(int new_area)
         sendServerMessage("You are already in area " + server->area_names[current_area]);
         return;
     }
-    if (server->areas[new_area]->locked == AreaData::LockStatus::LOCKED) {
+    if (server->areas[new_area]->locked == AreaData::LockStatus::LOCKED && !server->areas[new_area]->invited.contains(id)) {
         sendServerMessage("Area " + server->area_names[new_area] + " is locked.");
         return;
     }

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -248,7 +248,17 @@ void AOClient::setHwid(QString p_hwid)
 
 void AOClient::sendServerMessage(QString message)
 {
-    sendPacket("CT", {"Server", message, "1"});
+    sendPacket("CT", {server->getServerName(), message, "1"});
+}
+
+void AOClient::sendServerMessageArea(QString message)
+{
+    server->broadcast(AOPacket("CT", {server->getServerName(), message, "1"}), current_area);
+}
+
+void AOClient::sendServerBroadcast(QString message)
+{
+    server->broadcast(AOPacket("CT", {server->getServerName(), message, "1"}));
 }
 
 bool AOClient::checkAuth(unsigned long long acl_mask)

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -173,7 +173,21 @@ void AOClient::arup(ARUPType type, bool broadcast)
                 }
             }
         else if (type == ARUPType::LOCKED) {
-            arup_data.append(area->locked ? "LOCKED" : "FREE");
+            QString lock_status;
+            switch (area->locked) {
+                case FREE:
+                    lock_status = "FREE";
+                    break;
+                case LOCKED:
+                    lock_status = "LOCKED";
+                    break;
+                case SPECTATABLE:
+                    lock_status = "SPECTATABLE";
+                    break;
+                default:
+                    break;
+            }
+            arup_data.append(lock_status);
         }
         else return;
     }

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -103,10 +103,11 @@ void AOClient::changeArea(int new_area)
         sendServerMessage("You are already in area " + server->area_names[current_area]);
         return;
     }
-    if (server->areas[new_area]->locked) {
+    if (server->areas[new_area]->locked == AreaData::LockStatus::LOCKED) {
         sendServerMessage("Area " + server->area_names[new_area] + " is locked.");
         return;
     }
+
     if (current_char != "") {
         server->areas[current_area]->characters_taken[current_char] =
             false;
@@ -129,7 +130,9 @@ void AOClient::changeArea(int new_area)
         server->areas[current_area]->characters_taken[current_char] = true;
         server->updateCharsTaken(server->areas[current_area]);
     }
-    sendServerMessage("You have been moved to area " + server->area_names[current_area]);
+    sendServerMessage("You moved to area " + server->area_names[current_area]);
+    if (server->areas[current_area]->locked == AreaData::LockStatus::SPECTATABLE)
+        sendServerMessage("Area " + server->area_names[current_area] + " is spectate-only; to chat IC you will need to be invited by the CM.");
 }
 
 void AOClient::handleCommand(QString command, int argc, QStringList argv)
@@ -175,13 +178,13 @@ void AOClient::arup(ARUPType type, bool broadcast)
         else if (type == ARUPType::LOCKED) {
             QString lock_status;
             switch (area->locked) {
-                case FREE:
+                case AreaData::LockStatus::FREE:
                     lock_status = "FREE";
                     break;
-                case LOCKED:
+                case AreaData::LockStatus::LOCKED:
                     lock_status = "LOCKED";
                     break;
-                case SPECTATABLE:
+                case AreaData::LockStatus::SPECTATABLE:
                     lock_status = "SPECTATABLE";
                     break;
                 default:

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -264,8 +264,14 @@ void AOClient::sendServerBroadcast(QString message)
 bool AOClient::checkAuth(unsigned long long acl_mask)
 {
     if (acl_mask != ACLFlags.value("NONE")) {
-        if (!authenticated) {
+        if (!authenticated && acl_mask != ACLFlags.value("CM")) {
             return false;
+        }
+
+        if (acl_mask == ACLFlags.value("CM")) {
+            AreaData* area = server->areas[current_area];
+            if (area->owners.contains(id))
+                return true;
         }
 
         QSettings settings("config/config.ini", QSettings::IniFormat);

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -264,16 +264,14 @@ void AOClient::sendServerBroadcast(QString message)
 bool AOClient::checkAuth(unsigned long long acl_mask)
 {
     if (acl_mask != ACLFlags.value("NONE")) {
-        if (!authenticated && acl_mask != ACLFlags.value("CM")) {
-            return false;
-        }
-
         if (acl_mask == ACLFlags.value("CM")) {
             AreaData* area = server->areas[current_area];
             if (area->owners.contains(id))
                 return true;
         }
-
+        else if (!authenticated) {
+            return false;
+        }
         QSettings settings("config/config.ini", QSettings::IniFormat);
         settings.beginGroup("Options");
         QString auth_type = settings.value("auth", "simple").toString();

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -171,10 +171,10 @@ void AOClient::arup(ARUPType type, bool broadcast)
                 for (int owner_id : area->owners) {
                     AOClient* owner = server->getClientByID(owner_id);
                     area_owners.append("[" + QString::number(owner->id) + "] " + owner->current_char);
-                    }
-                arup_data.append(area_owners.join(", "));
                 }
+                arup_data.append(area_owners.join(", "));
             }
+        }
         else if (type == ARUPType::LOCKED) {
             QString lock_status;
             switch (area->locked) {

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -68,6 +68,11 @@ void AOClient::clientDisconnected()
             false;
         server->updateCharsTaken(server->areas[current_area]);
     }
+    for (AreaData* area : server->areas) {
+        area->owners.removeAll(id);
+        area->invited.removeAll(id);
+    }
+    arup(ARUPType::CM, true);
 }
 
 void AOClient::handlePacket(AOPacket packet)

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -17,11 +17,12 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include "include/aoclient.h"
 
-AOClient::AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent)
+AOClient::AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent, int user_id)
     : QObject(parent)
 {
     socket = p_socket;
     server = p_server;
+    id = user_id;
     joined = false;
     password = "";
     current_area = 0;
@@ -155,8 +156,17 @@ void AOClient::arup(ARUPType type, bool broadcast)
             arup_data.append(area->status);
         }
         else if (type == ARUPType::CM) {
-            arup_data.append(area->current_cm);
-        }
+            if (area->owners.isEmpty())
+                arup_data.append("FREE");
+            else {
+                QStringList area_owners;
+                for (int owner_id : area->owners) {
+                    AOClient* owner = server->getClientByID(owner_id);
+                    area_owners.append("[" + QString::number(owner->id) + "] " + owner->current_char);
+                    }
+                arup_data.append(area_owners.join(", "));
+                }
+            }
         else if (type == ARUPType::LOCKED) {
             arup_data.append(area->locked ? "LOCKED" : "FREE");
         }

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -39,6 +39,7 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.beginGroup("Options");
     int log_size = config_ini.value("logbuffer", 50).toInt();
+    config_ini.endGroup();
     if (log_size == 0)
         log_size = 500;
     logger = new Logger(log_size, this);

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -27,6 +27,7 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     QSettings areas_ini("areas.ini", QSettings::IniFormat);
     areas_ini.beginGroup(p_name);
     background = areas_ini.value("background", "gs4").toString();
+    is_protected = areas_ini.value("protected_area").toString().startsWith("true");
     areas_ini.endGroup();
     player_count = 0;
     locked = FREE;

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -24,10 +24,10 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     for (QString cur_char : characters) {
         characters_taken.insert(cur_char, false);
     }
-    QSettings areas_ini("areas.ini", QSettings::IniFormat);
+    QSettings areas_ini("config/areas.ini", QSettings::IniFormat);
     areas_ini.beginGroup(p_name);
     background = areas_ini.value("background", "gs4").toString();
-    is_protected = areas_ini.value("protected_area").toString().startsWith("true");
+    is_protected = areas_ini.value("protected_area").toBool();
     areas_ini.endGroup();
     player_count = 0;
     locked = FREE;

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -29,12 +29,12 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     background = areas_ini.value("background", "gs4").toString();
     areas_ini.endGroup();
     player_count = 0;
-    current_cm = "FREE";
-    locked = false;
+    locked = FREE;
     status = "FREE";
     def_hp = 10;
     pro_hp = 10;
     bg_locked = false;
+    document = "No document.";
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.beginGroup("Options");
     int log_size = config_ini.value("logbuffer", 50).toInt();

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -415,16 +415,20 @@ void AOClient::cmdCM(int argc, QStringList argv)
 {
     QString sender_name = ooc_name;
     AreaData* area = server->areas[current_area];
-    if (area->owners.isEmpty()) {
+    if (area->is_protected) {
+        sendServerMessage("This area is protected, you may not become CM.");
+        return;
+    }
+    else if (area->owners.isEmpty()) { // no one owns this area, and it's not protected
         area->owners.append(id);
         area->invited.append(id);
         sendServerMessageArea(sender_name + " is now CM in this area.");
         arup(ARUPType::CM, true);
     }
-    else if (!area->owners.contains(id)) {
+    else if (!area->owners.contains(id)) { // there is already a CM, and it isn't us
         sendServerMessage("You cannot become a CM in this area.");
     }
-    else if (argc == 1) {
+    else if (argc == 1) { // we are CM, and we want to make ID argv[0] also CM
         bool ok;
         AOClient* owner_candidate = server->getClientByID(argv[0].toInt(&ok));
         if (!ok) {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -188,7 +188,7 @@ void AOClient::cmdSetBackground(int argc, QStringList argv)
         if (server->backgrounds.contains(argv[0])) {
             area->background = argv[0];
             server->broadcast(AOPacket("BN", {argv[0]}), current_area);
-            server->broadcast(AOPacket("CT", {"Server", current_char + " changed the background to " + argv[0], "1"}), current_area);
+            sendServerMessageArea(current_char + " changed the background to " + argv[0]);
         }
         else {
             sendServerMessage("Invalid background name.");
@@ -385,7 +385,7 @@ void AOClient::cmdNeed(int argc, QStringList argv)
 void AOClient::cmdFlip(int argc, QStringList argv)
 {
     QString sender_name = ooc_name;
-    QStringList faces = {"head","tails"};
+    QStringList faces = {"heads","tails"};
     QString face = faces[AOClient::genRand(0,1)];
     sendServerMessage(sender_name + " flipped a coin and got " + face + ".");
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -399,7 +399,7 @@ void AOClient::cmdDoc(int argc, QStringList argv)
     }
     else {
         area->document = argv.join(" ");
-        sendServerMessage(sender_name + " changed the document."); // broadcast this!
+        sendServerMessageArea(sender_name + " changed the document.");
     }
 }
 
@@ -408,7 +408,7 @@ void AOClient::cmdClearDoc(int argc, QStringList argv)
     QString sender_name = ooc_name;
     AreaData* area = server->areas[current_area];
     area->document = "No document.";
-    sendServerMessage(sender_name + " cleared the document."); // broadcast this!
+    sendServerMessageArea(sender_name + " cleared the document.");
 }
 
 void AOClient::cmdCM(int argc, QStringList argv)
@@ -418,7 +418,7 @@ void AOClient::cmdCM(int argc, QStringList argv)
     if (area->owners.isEmpty()) {
         area->owners.append(id);
         area->invited.append(id);
-        sendServerMessage(sender_name + " is now CM in this area."); // broadcast this!
+        sendServerMessageArea(sender_name + " is now CM in this area.");
         arup(ARUPType::CM, true);
     }
     else if (!area->owners.contains(id)) {
@@ -436,7 +436,7 @@ void AOClient::cmdCM(int argc, QStringList argv)
             return;
         }
         area->owners.append(owner_candidate->id);
-        sendServerMessage(owner_candidate->ooc_name + " is now CM in this area."); // broadcast this!
+        sendServerMessageArea(owner_candidate->ooc_name + " is now CM in this area.");
         arup(ARUPType::CM, true);
     }
     else {
@@ -512,7 +512,7 @@ void AOClient::cmdLock(int argc, QStringList argv)
         sendServerMessage("This area is already locked.");
         return;
     }
-    sendServerMessage("This area is now locked."); // broadcast me!
+    sendServerMessageArea("This area is now locked.");
     area->locked = AreaData::LockStatus::LOCKED;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
@@ -532,7 +532,7 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
         sendServerMessage("This area is already in spectate mode.");
         return;
     }
-    sendServerMessage("This area is now spectatable."); // broadcast me!
+    sendServerMessageArea("This area is now spectatable.");
     area->locked = AreaData::LockStatus::SPECTATABLE;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
@@ -552,7 +552,7 @@ void AOClient::cmdUnLock(int argc, QStringList argv)
         sendServerMessage("This area is not locked.");
         return;
     }
-    sendServerMessage("This area is now unlocked."); // broadcast me!
+    sendServerMessageArea("This area is now unlocked.");
     area->locked = AreaData::LockStatus::FREE;
     arup(ARUPType::LOCKED, true);
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -508,12 +508,12 @@ void AOClient::cmdLock(int argc, QStringList argv)
         sendServerMessage("You are not a CM in this area.");
         return; 
     }
-    else if (area->locked == LOCKED) {
+    else if (area->locked == AreaData::LockStatus::LOCKED) {
         sendServerMessage("This area is already locked.");
         return;
     }
     sendServerMessage("This area is now locked.");
-    area->locked = LOCKED;
+    area->locked = AreaData::LockStatus::LOCKED;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
             area->invited.append(client->id);
@@ -528,12 +528,12 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
         sendServerMessage("You are not a CM in this area.");
         return; 
     }
-    else if (area->locked == SPECTATABLE) {
+    else if (area->locked == AreaData::LockStatus::SPECTATABLE) {
         sendServerMessage("This area is already in spectate mode.");
         return;
     }
     sendServerMessage("This area is now spectatable.");
-    area->locked = SPECTATABLE;
+    area->locked = AreaData::LockStatus::SPECTATABLE;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
             area->invited.append(client->id);
@@ -548,12 +548,12 @@ void AOClient::cmdUnLock(int argc, QStringList argv)
         sendServerMessage("You are not a CM in this area.");
         return; 
     }
-    else if (area->locked == FREE) {
+    else if (area->locked == AreaData::LockStatus::FREE) {
         sendServerMessage("This area is not locked.");
         return;
     }
     sendServerMessage("This area is now unlocked.");
-    area->locked = FREE;
+    area->locked = AreaData::LockStatus::FREE;
     arup(ARUPType::LOCKED, true);
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -471,6 +471,8 @@ QStringList AOClient::buildAreaList(int area_idx)
             QString char_entry = "[" + QString::number(client->id) + "] " + client->current_char;
             if (client->current_char == "")
                 char_entry += "Spectator";
+            if (area->owners.contains(client->id))
+                char_entry.insert(0, "[CM] ");
             if (authenticated)
                 char_entry += " (" + client->getIpid() + "): " + client->ooc_name;
             entries.append(char_entry);

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -564,6 +564,17 @@ QStringList AOClient::buildAreaList(int area_idx)
     QString area_name = server->area_names[area_idx];
     AreaData* area = server->areas[area_idx];
     entries.append("=== " + area_name + " ===");
+    switch (area->locked) {
+        case AreaData::LockStatus::LOCKED:
+            entries.append("[LOCKED]");
+            break;
+        case AreaData::LockStatus::SPECTATABLE:
+            entries.append("[SPECTATABLE]");
+            break;
+        case AreaData::LockStatus::FREE:
+        default:
+            break;
+    }
     entries.append("[" + QString::number(area->player_count) + " users][" + area->status + "]");
     for (AOClient* client : server->clients) {
         if (client->current_area == area_idx && client->joined) {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -512,7 +512,7 @@ void AOClient::cmdLock(int argc, QStringList argv)
         sendServerMessage("This area is already locked.");
         return;
     }
-    sendServerMessage("This area is now locked.");
+    sendServerMessage("This area is now locked."); // broadcast me!
     area->locked = AreaData::LockStatus::LOCKED;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
@@ -532,7 +532,7 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
         sendServerMessage("This area is already in spectate mode.");
         return;
     }
-    sendServerMessage("This area is now spectatable.");
+    sendServerMessage("This area is now spectatable."); // broadcast me!
     area->locked = AreaData::LockStatus::SPECTATABLE;
     for (AOClient* client : server->clients) {
         if (client->current_area == current_area && client->joined) {
@@ -552,7 +552,7 @@ void AOClient::cmdUnLock(int argc, QStringList argv)
         sendServerMessage("This area is not locked.");
         return;
     }
-    sendServerMessage("This area is now unlocked.");
+    sendServerMessage("This area is now unlocked."); // broadcast me!
     area->locked = AreaData::LockStatus::FREE;
     arup(ARUPType::LOCKED, true);
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -448,12 +448,8 @@ void AOClient::cmdUnCM(int argc, QStringList argv)
     AreaData* area = server->areas[current_area];
     int removed = area->owners.removeAll(id);
     area->invited.removeAll(id);
-    if (removed == 0)
-        sendServerMessage("You are not a CM in this area.");
-    else {
-        sendServerMessage("You are no longer CM in this area.");
-        arup(ARUPType::CM, true);
-    }
+    sendServerMessage("You are no longer CM in this area.");
+    arup(ARUPType::CM, true);
     if (area->owners.isEmpty())
         area->invited.clear();
 }
@@ -462,11 +458,7 @@ void AOClient::cmdInvite(int argc, QStringList argv)
     AreaData* area = server->areas[current_area];
     bool ok;
     int invited_id = argv[0].toInt(&ok);
-    if (!area->owners.contains(id)) {
-        sendServerMessage("You are not a CM in this area.");
-        return;
-    }
-    else if (!ok) {
+    if (!ok) {
         sendServerMessage("That does not look like a valid ID.");
         return;
     }
@@ -482,11 +474,7 @@ void AOClient::cmdUnInvite(int argc, QStringList argv)
     AreaData* area = server->areas[current_area];
     bool ok;
     int uninvited_id = argv[0].toInt(&ok);
-    if (!area->owners.contains(id)) {
-        sendServerMessage("You are not a CM in this area.");
-        return;
-    }
-    else if (!ok) {
+    if (!ok) {
         sendServerMessage("That does not look like a valid ID.");
         return;
     }
@@ -504,11 +492,7 @@ void AOClient::cmdUnInvite(int argc, QStringList argv)
 void AOClient::cmdLock(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
-    if (!area->owners.contains(id)) {
-        sendServerMessage("You are not a CM in this area.");
-        return; 
-    }
-    else if (area->locked == AreaData::LockStatus::LOCKED) {
+    if (area->locked == AreaData::LockStatus::LOCKED) {
         sendServerMessage("This area is already locked.");
         return;
     }
@@ -524,11 +508,7 @@ void AOClient::cmdLock(int argc, QStringList argv)
 void AOClient::cmdSpectatable(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
-    if (!area->owners.contains(id)) {
-        sendServerMessage("You are not a CM in this area.");
-        return; 
-    }
-    else if (area->locked == AreaData::LockStatus::SPECTATABLE) {
+    if (area->locked == AreaData::LockStatus::SPECTATABLE) {
         sendServerMessage("This area is already in spectate mode.");
         return;
     }
@@ -544,11 +524,7 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
 void AOClient::cmdUnLock(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
-    if (!area->owners.contains(id)) {
-        sendServerMessage("You are not a CM in this area.");
-        return; 
-    }
-    else if (area->locked == AreaData::LockStatus::FREE) {
+    if (area->locked == AreaData::LockStatus::FREE) {
         sendServerMessage("This area is not locked.");
         return;
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -454,6 +454,8 @@ void AOClient::cmdUnCM(int argc, QStringList argv)
         sendServerMessage("You are no longer CM in this area.");
         arup(ARUPType::CM, true);
     }
+    if (area->owners.isEmpty())
+        area->invited.clear();
 }
 void AOClient::cmdInvite(int argc, QStringList argv)
 {
@@ -498,6 +500,61 @@ void AOClient::cmdUnInvite(int argc, QStringList argv)
     }
     area->invited.removeAll(uninvited_id);
     sendServerMessage("You uninvited ID " + argv[0]);
+}
+void AOClient::cmdLock(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    if (!area->owners.contains(id)) {
+        sendServerMessage("You are not a CM in this area.");
+        return; 
+    }
+    else if (area->locked == LOCKED) {
+        sendServerMessage("This area is already locked.");
+        return;
+    }
+    sendServerMessage("This area is now locked.");
+    area->locked = LOCKED;
+    for (AOClient* client : server->clients) {
+        if (client->current_area == current_area && client->joined) {
+            area->invited.append(client->id);
+        }
+    }
+    arup(ARUPType::LOCKED, true);
+}
+void AOClient::cmdSpectatable(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    if (!area->owners.contains(id)) {
+        sendServerMessage("You are not a CM in this area.");
+        return; 
+    }
+    else if (area->locked == SPECTATABLE) {
+        sendServerMessage("This area is already in spectate mode.");
+        return;
+    }
+    sendServerMessage("This area is now spectatable.");
+    area->locked = SPECTATABLE;
+    for (AOClient* client : server->clients) {
+        if (client->current_area == current_area && client->joined) {
+            area->invited.append(client->id);
+        }
+    }
+    arup(ARUPType::LOCKED, true);
+}
+void AOClient::cmdUnLock(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    if (!area->owners.contains(id)) {
+        sendServerMessage("You are not a CM in this area.");
+        return; 
+    }
+    else if (area->locked == FREE) {
+        sendServerMessage("This area is not locked.");
+        return;
+    }
+    sendServerMessage("This area is now unlocked.");
+    area->locked = FREE;
+    arup(ARUPType::LOCKED, true);
 }
 
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -51,7 +51,7 @@ void Logger::logCmd(AOClient *client, AOPacket *packet, QString cmd, QStringList
     else if (cmd == "rootpass") {
         addEntry(buildEntry(client, "USERS", "Root password created"));
     }
-    else if (cmd == "adduser") {
+    else if (cmd == "adduser" && !args.isEmpty()) {
         addEntry(buildEntry(client, "USERS", "Added user " + args[0]));
     }
     else

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -319,6 +319,10 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
         // Spectators cannot use IC
         return invalid;
 
+    if (current_area->locked == SPECTATABLE && !current_area->invited.contains(id))
+        // Non-invited players cannot speak in spectatable areas
+        return invalid;
+
     QList<QVariant> incoming_args;
     for (QString arg : packet.contents) {
         incoming_args.append(QVariant(arg));

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -142,6 +142,7 @@ void AOClient::pktSelectChar(AreaData* area, int argc, QStringList argv, AOPacke
 
     server->updateCharsTaken(area);
     sendPacket("PV", {"271828", "CID", argv[1]});
+    fullArup();
 }
 
 void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket packet)

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -318,8 +318,8 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     if (current_char == "" || !joined)
         // Spectators cannot use IC
         return invalid;
-
-    if (current_area->locked == SPECTATABLE && !current_area->invited.contains(id))
+    AreaData* area = server->areas[current_area];
+    if (area->locked == AreaData::LockStatus::SPECTATABLE && !area->invited.contains(id))
         // Non-invited players cannot speak in spectatable areas
         return invalid;
 
@@ -410,7 +410,6 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
 
     // evidence
     int evi_idx = incoming_args[11].toInt();
-    AreaData* area = server->areas[current_area];
     if (evi_idx > area->evidence.length())
         return invalid;
     args.append(QString::number(evi_idx));

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -141,7 +141,7 @@ void AOClient::pktSelectChar(AreaData* area, int argc, QStringList argv, AOPacke
     pos = "";
 
     server->updateCharsTaken(area);
-    sendPacket("PV", {"271828", "CID", argv[1]});
+    sendPacket("PV", {QString::number(id), "CID", argv[1]});
     fullArup();
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -82,10 +82,6 @@ void Server::start()
     for (int i = 0; i < area_names.length(); i++) {
         QString area_name = area_names[i];
         areas.insert(i, new AreaData(characters, area_name, i));
-        areas_ini.beginGroup(area_name);
-        // TODO: more area config
-        areas[i]->background = areas_ini.value("background", "gs4").toString();
-        areas_ini.endGroup();
     }
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -92,7 +92,18 @@ void Server::start()
 void Server::clientConnected()
 {
     QTcpSocket* socket = server->nextPendingConnection();
-    AOClient* client = new AOClient(this, socket, this);
+    int user_id;
+    QList<int> user_ids;
+    for (AOClient* client : clients) {
+        user_ids.append(client->id);
+    }
+    for (user_id = 0; user_id <= player_count; user_id++) {
+        if (user_ids.contains(user_id))
+            continue;
+        else
+            break;
+    }
+    AOClient* client = new AOClient(this, socket, this, user_id);
     if (db_manager->isIPBanned(socket->peerAddress())) {
         AOPacket ban_reason("BD", {db_manager->getBanReason(socket->peerAddress())});
         socket->write(ban_reason.toUtf8());
@@ -151,6 +162,15 @@ AOClient* Server::getClient(QString ipid)
 {
     for (AOClient* client : clients) {
         if (client->getIpid() == ipid)
+            return client;
+    }
+    return nullptr;
+}
+
+AOClient* Server::getClientByID(int id)
+{
+    for (AOClient* client : clients) {
+        if (client->id == id)
             return client;
     }
     return nullptr;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -158,6 +158,14 @@ void Server::broadcast(AOPacket packet)
     }
 }
 
+QString Server::getServerName()
+{
+    QSettings settings("config/config.ini", QSettings::IniFormat);
+    settings.beginGroup("Options");
+    QString server_name = settings.value("server_name", "Akashi").toString();
+    return server_name;
+}
+
 AOClient* Server::getClient(QString ipid)
 {
     for (AOClient* client : clients) {


### PR DESCRIPTION
User IDs are a clone of the existing functionality in tsuserver3. On connection, the client is given the first available ID.
The "current_cm" area parameter has been replaced with a QList of IDs called "owners". Commands that should be limited to CMs can check the client's ID against the list of owners.