### PR TITLE
Change cmdKick and cmdBan to target by UID rather than IPID

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -86,6 +86,7 @@ void AOClient::cmdGetArea(int argc, QStringList argv)
 
 void AOClient::cmdBan(int argc, QStringList argv)
 {
+    bool ok;
     int target_id = argv[0].toInt(&ok);
     if (!ok) {
         sendServerMessage("Invalid ID.");

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -86,7 +86,7 @@ void AOClient::cmdGetArea(int argc, QStringList argv)
 
 void AOClient::cmdBan(int argc, QStringList argv)
 {
-    QString target_ipid = argv[0];
+    QString target_ipid = argv[0]; //targeted by IPID so that bans can be entered for offline users
     QHostAddress ip;
     QString hdid;
     unsigned long time = QDateTime::currentDateTime().toTime_t();
@@ -120,7 +120,7 @@ void AOClient::cmdBan(int argc, QStringList argv)
 void AOClient::cmdKick(int argc, QStringList argv)
 {
     bool ok;
-    int target_id = argv[0].toInt(&ok);
+    int target_id = argv[0].toInt(&ok); // targeted by UID because kicks can only be performed on online users
     if (!ok) {
         sendServerMessage("Invalid ID.");
         return;
@@ -134,8 +134,10 @@ void AOClient::cmdKick(int argc, QStringList argv)
         }
     }
 
+    AOClient* target_client = server->getClientByID(target_id);
+    QString target_ipid = target_client->getIpid();
     for (AOClient* client : server->clients) {
-        if (client->id == target_id) {
+        if (client->getIpid() == target_ipid) {
             client->sendPacket("KK", {reason});
             client->socket->close();
             did_kick = true;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -127,6 +127,7 @@ void AOClient::cmdKick(int argc, QStringList argv)
     }
     QString reason = argv[1];
     bool did_kick = false;
+    int kicked_counter = 0;
 
     if (argc > 2) {
         for (int i = 2; i < argv.length(); i++) {
@@ -141,11 +142,12 @@ void AOClient::cmdKick(int argc, QStringList argv)
             client->sendPacket("KK", {reason});
             client->socket->close();
             did_kick = true;
+            kicked_counter++;
         }
     }
 
     if (did_kick)
-        sendServerMessage("Kicked user with id " + QString::number(target_id) + " for reason: " + reason);
+        sendServerMessage("Kicked " + QString::number(kicked_counter) + " users with ipids matching id " + QString::number(target_id) + " for reason: " + reason);
     else
         sendServerMessage("User with id " + QString::number(target_id) + " not found!");
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -114,12 +114,17 @@ void AOClient::cmdBan(int argc, QStringList argv)
     }
 
     if (!ban_logged)
-        sendServerMessage("User with ipid not found!");
+        sendServerMessage("User with ipid " + taget_ipid + " not found!");
 }
 
 void AOClient::cmdKick(int argc, QStringList argv)
 {
-    QString target_ipid = argv[0];
+    bool ok;
+    int target_id = argv[0].toInt(&ok);
+    if (!ok) {
+        sendServerMessage("Invalid ID.");
+        return;
+    }
     QString reason = argv[1];
     bool did_kick = false;
 
@@ -130,7 +135,7 @@ void AOClient::cmdKick(int argc, QStringList argv)
     }
 
     for (AOClient* client : server->clients) {
-        if (client->getIpid() == target_ipid) {
+        if (client->id == target_id) {
             client->sendPacket("KK", {reason});
             client->socket->close();
             did_kick = true;
@@ -138,9 +143,9 @@ void AOClient::cmdKick(int argc, QStringList argv)
     }
 
     if (did_kick)
-        sendServerMessage("Kicked user with ipid " + target_ipid + " for reason: " + reason);
+        sendServerMessage("Kicked user with id " + QString::number(target_id) + " for reason: " + reason);
     else
-        sendServerMessage("User with ipid not found!");
+        sendServerMessage("User with id " + QString::number(target_id) + " not found!");
 }
 
 void AOClient::cmdChangeAuth(int argc, QStringList argv)


### PR DESCRIPTION
Resolves #10. Kicking a client by their UID will also kick any clients with the same IPID, and report how many clients were kicked to the moderator. Banning works much the same way.