### PR TITLE
Add support for 2.9 timers

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -64,6 +64,7 @@ class AOClient : public QObject {
         {"BGLOCK", 1ULL << 2},
         {"MODIFY_USERS", 1ULL << 3},
         {"CM", 1ULL << 4},
+        {"GLOBAL_TIMER", 1ULL << 5},
         {"SUPER", ~0ULL}
     };
 
@@ -198,11 +199,13 @@ class AOClient : public QObject {
     void cmdRollP(int argc, QStringList argv);
     void cmdDoc(int argc, QStringList argv);
     void cmdClearDoc(int argc, QStringList argv);
+    void cmdTimer(int argc, QStringList argv);
     // Messaging/Client
     void cmdPos(int argc, QStringList argv);
     void cmdG(int argc, QStringList argv);
 
     // Command helper functions
+    QString getAreaTimer(int area_idx, QTimer* timer);
     QStringList buildAreaList(int area_idx);
     int genRand(int min, int max);
     void diceThrower(int argc, QStringList argv, RollType Type);
@@ -249,6 +252,7 @@ class AOClient : public QObject {
         {"lock", {ACLFlags.value("CM"), 0, &AOClient::cmdLock}},
         {"spectatable", {ACLFlags.value("CM"), 0, &AOClient::cmdSpectatable}},
         {"unlock", {ACLFlags.value("CM"), 0, &AOClient::cmdUnLock}},
+        {"timer", {ACLFlags.value("NONE"), 0, &AOClient::cmdTimer}},
     };
 
     QString partial_packet;

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -252,7 +252,7 @@ class AOClient : public QObject {
         {"lock", {ACLFlags.value("CM"), 0, &AOClient::cmdLock}},
         {"spectatable", {ACLFlags.value("CM"), 0, &AOClient::cmdSpectatable}},
         {"unlock", {ACLFlags.value("CM"), 0, &AOClient::cmdUnLock}},
-        {"timer", {ACLFlags.value("NONE"), 0, &AOClient::cmdTimer}},
+        {"timer", {ACLFlags.value("CM"), 0, &AOClient::cmdTimer}},
     };
 
     QString partial_packet;

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -24,6 +24,8 @@
 #include <QString>
 #include <QSettings>
 #include <QDebug>
+#include <QTimer>
+#include <QElapsedTimer>
 
 class Logger;
 class AreaData {
@@ -35,7 +37,7 @@ class AreaData {
         QString description;
         QString image;
     };
-
+    QList<QTimer*> timers;
     QString name;
     int index;
     QMap<QString, bool> characters_taken;

--- a/include/server.h
+++ b/include/server.h
@@ -32,6 +32,7 @@
 #include <QString>
 #include <QTcpServer>
 #include <QTcpSocket>
+#include <QTimer>
 
 class AOClient;
 class DBManager;
@@ -63,6 +64,8 @@ class Server : public QObject {
     QStringList backgrounds;
     DBManager* db_manager;
     QString server_name;
+
+    QTimer* timer;
 
   signals:
 

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -130,6 +130,16 @@ void AOClient::changeArea(int new_area)
         server->areas[current_area]->characters_taken[current_char] = true;
         server->updateCharsTaken(server->areas[current_area]);
     }
+    for (QTimer* timer : server->areas[current_area]->timers) {
+        int timer_id = server->areas[current_area]->timers.indexOf(timer) + 1;
+        if (timer->isActive()) {
+            sendPacket("TI", {QString::number(timer_id), QString::number(2)});
+            sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(QTime(0,0).msecsTo(QTime(0,0).addMSecs(timer->remainingTime())))});
+        }
+        else {
+            sendPacket("TI", {QString::number(timer_id), QString::number(3)});
+        }
+    }
     sendServerMessage("You moved to area " + server->area_names[current_area]);
     if (server->areas[current_area]->locked == AreaData::LockStatus::SPECTATABLE)
         sendServerMessage("Area " + server->area_names[current_area] + " is spectate-only; to chat IC you will need to be invited by the CM.");

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -43,12 +43,12 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     if (log_size == 0)
         log_size = 500;
     logger = new Logger(log_size, this);
-    QTimer* timer1;
+    QTimer* timer1 = new QTimer();
     timers.append(timer1);
-    QTimer* timer2;
+    QTimer* timer2 = new QTimer();
     timers.append(timer2);
-    QTimer* timer3;
+    QTimer* timer3 = new QTimer();
     timers.append(timer3);
-    QTimer* timer4;
+    QTimer* timer4 = new QTimer();
     timers.append(timer4);
 }

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -43,4 +43,12 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     if (log_size == 0)
         log_size = 500;
     logger = new Logger(log_size, this);
+    QTimer* timer1;
+    timers.append(timer1);
+    QTimer* timer2;
+    timers.append(timer2);
+    QTimer* timer3;
+    timers.append(timer3);
+    QTimer* timer4;
+    timers.append(timer4);
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -619,13 +619,13 @@ void AOClient::cmdTimer(int argc, QStringList argv)
             requested_timer->start();
             sendServerMessage("Started timer " + QString::number(timer_id) + ".");
             sendPacket("TI", {QString::number(timer_id), QString::number(2)});
-            sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(requested_timer->remainingTime())});
+            sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(QTime(0,0).msecsTo(QTime(0,0).addMSecs(requested_timer->remainingTime())))});
         }
         else if (argv[1] == "pause" || argv[1] == "stop") {
             requested_timer->setInterval(requested_timer->remainingTime());
             requested_timer->stop();
             sendServerMessage("Stopped timer " + QString::number(timer_id) + ".");
-            sendPacket("TI", {QString::number(timer_id), QString::number(1), QString::number(requested_timer->remainingTime())});
+            sendPacket("TI", {QString::number(timer_id), QString::number(1), QString::number(QTime(0,0).msecsTo(QTime(0,0).addMSecs(requested_timer->interval())))});
         }
         else if (argv[1] == "hide" || argv[1] == "unset") {
             requested_timer->setInterval(0);
@@ -744,7 +744,7 @@ QString AOClient::getAreaTimer(int area_idx, QTimer* timer)
 {
     AreaData* area = server->areas[area_idx];
     if (timer->isActive()) {
-        QTime current_time = QTime(0,0,0,timer->remainingTime());
+        QTime current_time = QTime(0,0).addMSecs(timer->remainingTime());
         return "Timer " + QString::number(area->timers.indexOf(timer) + 1) + " is at " + current_time.toString("hh:mm:ss.zzz");
     }
     else {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -566,10 +566,8 @@ void AOClient::cmdTimer(int argc, QStringList argv)
             QTime current_time(0, 0, 0, global_timer->remainingTime());
             timers.append("Global timer is at " + current_time.toString("hh:mm:ss.zzz"));
         }
-        for (AreaData* area : server->areas) {
-            for (QTimer* timer : area->timers) {
-                timers.append(getAreaTimer(area->index, timer));
-            }
+        for (QTimer* timer : area->timers) {
+            timers.append(getAreaTimer(area->index, timer));
         }
         sendServerMessage(timers.join("\n"));
         return;
@@ -585,7 +583,7 @@ void AOClient::cmdTimer(int argc, QStringList argv)
         if (timer_id == 0) {
             QTimer* global_timer = server->timer;
             if (global_timer->isActive()) {
-                QTime current_time(0, 0, 0, global_timer->remainingTime());
+                QTime current_time = QTime(0, 0, 0, global_timer->remainingTime());
                 sendServerMessage("Global timer is at " + current_time.toString("hh:mm:ss.zzz"));
                 return;
             }
@@ -612,6 +610,7 @@ void AOClient::cmdTimer(int argc, QStringList argv)
         requested_timer->setInterval(QTime(0,0).msecsTo(requested_time));
         requested_timer->start();
         sendServerMessage("Set timer " + QString::number(timer_id) + " to " + argv[1] + ".");
+        sendPacket("TI", {QString::number(timer_id), QString::number(2)});
         sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(QTime(0,0).msecsTo(requested_time))});
         return;
     }
@@ -619,6 +618,7 @@ void AOClient::cmdTimer(int argc, QStringList argv)
         if (argv[1] == "start") {
             requested_timer->start();
             sendServerMessage("Started timer " + QString::number(timer_id) + ".");
+            sendPacket("TI", {QString::number(timer_id), QString::number(2)});
             sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(requested_timer->remainingTime())});
         }
         else if (argv[1] == "pause" || argv[1] == "stop") {
@@ -744,11 +744,11 @@ QString AOClient::getAreaTimer(int area_idx, QTimer* timer)
 {
     AreaData* area = server->areas[area_idx];
     if (timer->isActive()) {
-        QTime current_time (0,0,0,timer->remainingTime());
+        QTime current_time = QTime(0,0,0,timer->remainingTime());
         return "Timer " + QString::number(area->timers.indexOf(timer) + 1) + " is at " + current_time.toString("hh:mm:ss.zzz");
     }
     else {
-        return "Timer " + QString::number(area->timers.indexOf(timer) + 1) + "is inactive.";
+        return "Timer " + QString::number(area->timers.indexOf(timer) + 1) + " is inactive.";
     }
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -563,7 +563,7 @@ void AOClient::cmdTimer(int argc, QStringList argv)
         timers.append("Currently active timers:");
         QTimer* global_timer = server->timer;
         if (global_timer->isActive()) {
-            QTime current_time(0, 0, 0, global_timer->remainingTime());
+            QTime current_time = QTime(0,0).addMSecs(global_timer->remainingTime());
             timers.append("Global timer is at " + current_time.toString("hh:mm:ss.zzz"));
         }
         for (QTimer* timer : area->timers) {

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -143,6 +143,23 @@ void AOClient::pktSelectChar(AreaData* area, int argc, QStringList argv, AOPacke
     server->updateCharsTaken(area);
     sendPacket("PV", {QString::number(id), "CID", argv[1]});
     fullArup();
+    if (server->timer->isActive()) {
+        sendPacket("TI", {QString::number(0), QString::number(2)});
+        sendPacket("TI", {QString::number(0), QString::number(0), QString::number(QTime(0,0).msecsTo(QTime(0,0).addMSecs(server->timer->remainingTime())))});
+    }
+    else {
+        sendPacket("TI", {QString::number(0), QString::number(3)});
+    }
+    for (QTimer* timer : area->timers) {
+        int timer_id = area->timers.indexOf(timer) + 1;
+        if (timer->isActive()) {
+            sendPacket("TI", {QString::number(timer_id), QString::number(2)});
+            sendPacket("TI", {QString::number(timer_id), QString::number(0), QString::number(QTime(0,0).msecsTo(QTime(0,0).addMSecs(timer->remainingTime())))});
+        }
+        else {
+            sendPacket("TI", {QString::number(timer_id), QString::number(3)});
+        }
+    }
 }
 
 void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket packet)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -24,6 +24,7 @@ Server::Server(int p_port, int p_ws_port, QObject* parent) : QObject(parent)
 
     port = p_port;
     ws_port = p_ws_port;
+    timer = new QTimer();
 
     player_count = 0;
 


### PR DESCRIPTION
Timer 0 is the server-wide timer, and requires the `GLOBAL_TIMER` permission to alter. Implementation is otherwise identical to https://github.com/Crystalwarrior/KFO-Server.