### PR TITLE
Add rudimentary iniswap prevention

### DIFF
--- a/bin/config_sample/areas.ini
+++ b/bin/config_sample/areas.ini
@@ -1,5 +1,9 @@
 [Basement]
 background=gs4
+protected_area=true
+iniswap_allowed=false
 
 [Courtroom 1]
 background=gs4
+protected_area=false
+iniswap_allowed=true

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -27,7 +27,8 @@ AreaData::AreaData(QStringList characters, QString p_name, int p_index)
     QSettings areas_ini("config/areas.ini", QSettings::IniFormat);
     areas_ini.beginGroup(p_name);
     background = areas_ini.value("background", "gs4").toString();
-    is_protected = areas_ini.value("protected_area").toBool();
+    is_protected = areas_ini.value("protected_area", "false").toBool();
+    iniswap_allowed = areas_ini.value("iniswap_allowed", "true").toBool();
     areas_ini.endGroup();
     player_count = 0;
     locked = FREE;

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -362,10 +362,10 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     if (current_char != incoming_args[2].toString()) {
         // Selected char is different from supplied folder name
         // This means the user is INI-swapped
-        // TODO: ini swap locking
-        // if no iniswap allowed then
-        // if (!server->characters.contains(incoming_args[2].toString()))
-        //     return invalid;
+        if (!area->iniswap_allowed) {
+            if (!server->characters.contains(incoming_args[2].toString()))
+                return invalid;
+        }
         qDebug() << "INI swap detected from " << getIpid();
     }
     args.append(incoming_args[2].toString());


### PR DESCRIPTION
If `iniswap_allowed` is configured `false` and an IC packet is received where the current character selected and the character folder parameter do not match, the IC packet will be rejected as invalid. Proper emote-level checking is still not implemented.