### PR TITLE
Network authentication and support for expanded_desk_mods.

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -68,6 +68,10 @@ class AOClient : public QObject {
         {"SUPER", ~0ULL}
     };
 
+    bool is_shaken;
+    bool is_disemvoweled;
+    bool is_gimped;
+
   public slots:
     void clientDisconnected();
     void clientData();

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -40,10 +40,12 @@ void AOClient::cmdLogin(int argc, QStringList argv)
     // TODO: tell the user if no modpass is set
     if (auth_type == "simple") {
         if(argv[0] == modpass) {
-            sendServerMessage("Logged in as a moderator."); // This string has to be exactly this, because it is hardcoded in the client
+            //sendServerMessage("Logged in as a moderator."); // This string has to be exactly this, because it is hardcoded in the client
+            sendPacket("AUTH", {"1"});
             authenticated = true;
         } else {
             sendServerMessage("Incorrect password.");
+            sendPacket("AUTH", {"0"});
         }
         server->areas.value(current_area)->logger->logLogin(this, authenticated, "moderator");
     }
@@ -57,11 +59,12 @@ void AOClient::cmdLogin(int argc, QStringList argv)
         if (server->db_manager->authenticate(username, password)) {
             moderator_name = username;
             authenticated = true;
-            sendServerMessage("Logged in as a moderator.");
+            sendPacket("AUTH", {"1"});
             sendServerMessage("Welcome, " + username);
         }
         else {
             sendServerMessage("Incorrect password.");
+            sendPacket("AUTH", {"0"});
         }
         server->areas.value(current_area)->logger->logLogin(this, authenticated, username);
     }
@@ -359,6 +362,7 @@ void AOClient::cmdLogout(int argc, QStringList argv)
     authenticated = false;
     moderator_name = "";
     sendServerMessage("You have been logged out.");
+    sendPacket("AUTH", {"-1"});
 }
 
 void AOClient::cmdPos(int argc, QStringList argv)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -40,12 +40,12 @@ void AOClient::cmdLogin(int argc, QStringList argv)
     // TODO: tell the user if no modpass is set
     if (auth_type == "simple") {
         if(argv[0] == modpass) {
-            //sendServerMessage("Logged in as a moderator."); // This string has to be exactly this, because it is hardcoded in the client
-            sendPacket("AUTH", {"1"});
+            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
+            sendServerMessage("Logged in as a moderator."); // for old clients, this is hardcoded to display the mod UI
             authenticated = true;
         } else {
+            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
             sendServerMessage("Incorrect password.");
-            sendPacket("AUTH", {"0"});
         }
         server->areas.value(current_area)->logger->logLogin(this, authenticated, "moderator");
     }
@@ -59,12 +59,13 @@ void AOClient::cmdLogin(int argc, QStringList argv)
         if (server->db_manager->authenticate(username, password)) {
             moderator_name = username;
             authenticated = true;
-            sendPacket("AUTH", {"1"});
+            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
+            sendServerMessage("Logged in as a moderator."); // for old clients, this is hardcoded to display the mod UI
             sendServerMessage("Welcome, " + username);
         }
         else {
+            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
             sendServerMessage("Incorrect password.");
-            sendPacket("AUTH", {"0"});
         }
         server->areas.value(current_area)->logger->logLogin(this, authenticated, username);
     }
@@ -361,8 +362,7 @@ void AOClient::cmdLogout(int argc, QStringList argv)
     }
     authenticated = false;
     moderator_name = "";
-    sendServerMessage("You have been logged out.");
-    sendPacket("AUTH", {"-1"});
+    sendPacket("AUTH", {"-1"}); // Client: "You were logged out."
 }
 
 void AOClient::cmdPos(int argc, QStringList argv)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -43,7 +43,7 @@ void AOClient::cmdLogin(int argc, QStringList argv)
         }
         else if(argv[0] == modpass) {
             sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
-            sendServerMessage("Logged in as a moderator."); // for old clients, this is hardcoded to display the mod UI
+            sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
             authenticated = true;
         } 
         else {
@@ -63,7 +63,8 @@ void AOClient::cmdLogin(int argc, QStringList argv)
             moderator_name = username;
             authenticated = true;
             sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
-            sendServerMessage("Logged in as a moderator."); // for old clients, this is hardcoded to display the mod UI
+            if (version.release <= 2 && version.major <= 9 && version.minor <= 0)
+                sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
             sendServerMessage("Welcome, " + username);
         }
         else {

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -46,12 +46,12 @@ void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacke
     // The only ones that are critical to ensuring the server works are
     // "noencryption" and "fastloading"
     QStringList feature_list = {
-        "noencryption", "yellowtext",       "prezoom",
-        "flipping",     "customobjections", "fastloading",
-        "deskmod",      "evidence",         "cccc_ic_support",
-        "arup",         "casing_alerts",    "modcall_reason",
-        "looping_sfx",  "additive",         "effects",
-        "y_offset"
+        "noencryption", "yellowtext",         "prezoom",
+        "flipping",     "customobjections",   "fastloading",
+        "deskmod",      "evidence",           "cccc_ic_support",
+        "arup",         "casing_alerts",      "modcall_reason",
+        "looping_sfx",  "additive",           "effects",
+        "y_offset",     "expanded_desk_mods", "auth_packet"
     };
 
     sendPacket("PN", {QString::number(server->player_count), max_players});
@@ -345,15 +345,13 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
         incoming_args.append(QVariant(arg));
     }
 
-    // message type
-    if (incoming_args[0].toInt() == 1)
-        args.append("1");
-    else if (incoming_args[0].toInt() == 0) {
-        if (incoming_args[0].toString() == "chat")
-            args.append("chat");
-        else
-            args.append("0");
+    // desk modifier
+    QStringList allowed_desk_mods = ["chat", "0", "1", "2", "3", "4", "5"];
+    if (allowed_desk_mods.contains(incoming_args[0])) {
+        args.append(incoming_args[0]);
     }
+    else
+        return invalid;
 
     // preanim
     args.append(incoming_args[1].toString());

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -346,9 +346,10 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     }
 
     // desk modifier
-    QStringList allowed_desk_mods = ["chat", "0", "1", "2", "3", "4", "5"];
-    if (allowed_desk_mods.contains(incoming_args[0])) {
-        args.append(incoming_args[0]);
+    QStringList allowed_desk_mods;
+    allowed_desk_mods << "chat" << "0" << "1" << "2" << "3" << "4" << "5";
+    if (allowed_desk_mods.contains(incoming_args[0].toString())) {
+        args.append(incoming_args[0].toString());
     }
     else
         return invalid;


### PR DESCRIPTION
The AUTH packet is used like this:

**Server:** `AUTH#{state}#%`

`state`:
`1` or higher: Successful log-in. Displays the guard button.
`0`: Unsuccessful log-in attempt.
`-1` or lower: Log-out. Hides the guard button.