### PR TITLE
Fix-ICColor

### DIFF
--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -486,7 +486,7 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
 
     // text color
     int text_color = incoming_args[14].toInt();
-    if (text_color != 0 && text_color != 1 && text_color != 2 && text_color != 3 && text_color != 4 && text_color != 5 && text_color != 6)
+    if (text_color < 0 || text_color > 11)
         return invalid;
     args.append(QString::number(text_color));
 


### PR DESCRIPTION
The AO Client supports up to twelve colors by default. We might want to actually support all of them.