### PR TITLE
Fix shownames being set to a single space when the user does not specify one

### DIFF
--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -512,7 +512,8 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     if (incoming_args.length() > 15) {
         // showname
         QString incoming_showname = dezalgo(incoming_args[15].toString().trimmed());
-        if (incoming_showname.length() == 0)
+        // if the raw input is not empty but the trimmed input is, use a single space
+        if (incoming_showname.isEmpty() && !incoming_args[15].toString().isEmpty())
             incoming_showname = " ";
         args.append(incoming_showname);
         showname = incoming_showname;


### PR DESCRIPTION
Fixes #50.