### PR TITLE
Add /8ball and a text file to change its answers

### DIFF
--- a/bin/config_sample/text/8ball.txt
+++ b/bin/config_sample/text/8ball.txt
@@ -1,0 +1,20 @@
+It is certain.
+It is decidedly so.
+Without a doubt.
+Yes - definitely.
+You may rely on it.
+As I see it, yes.
+Most likely.
+Outlook good.
+Yes.
+Signs point to yes.
+Reply hazy, try again.
+Ask again later.
+Better not tell you now.
+Cannot predict now.
+Concentrate and ask again.
+Don't count on it.
+My reply is no.
+My sources say no.
+Outlook not so good.
+Very doubtful.

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1369,6 +1369,8 @@ class AOClient : public QObject {
      */
     void cmdPM(int argc, QStringList argv);
 
+    void cmd8Ball(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1560,6 +1562,7 @@ class AOClient : public QObject {
         {"notecard_reveal", {ACLFlags.value("CM"),           0, &AOClient::cmdNoteCardReveal}},
         {"notecardclear",   {ACLFlags.value("NONE"),         0, &AOClient::cmdNoteCardClear}},
         {"notecard_clear",  {ACLFlags.value("NONE"),         0, &AOClient::cmdNoteCardClear}},
+        {"8ball",           {ACLFlags.value("NONE"),         1, &AOClient::cmd8Ball}},
     };
 
     /**

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1369,6 +1369,13 @@ class AOClient : public QObject {
      */
     void cmdPM(int argc, QStringList argv);
 
+    /**
+     * @brief Randomly selects an answer from 8ball.txt to a question.
+     *
+     * @details The only argument is the question the client wants answered.
+     *
+     * @iscommand
+     */
     void cmd8Ball(int argc, QStringList argv);
 
     ///@}

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1240,6 +1240,39 @@ void AOClient::cmdNoteCardReveal(int argc, QStringList argv)
     area->notecards.clear();
 }
 
+void AOClient::cmd8Ball(int argc, QStringList argv)
+{
+    QFileInfo magic8ball_info("config/text/8ball.txt");
+    if (!(magic8ball_info.exists() && magic8ball_info.isFile())) {
+        qWarning() << "8ball.txt doesn't exist!";
+        sendServerMessage("8ball.txt doesn't exist.");
+    }
+    else {
+        QStringList answers;
+        QFile file("config/text/8ball.txt");
+        file.open(QIODevice::ReadOnly | QIODevice::Text);
+        while (!file.atEnd()) {
+            answers.append(file.readLine().trimmed());
+        }
+        file.close();
+
+        if (answers.isEmpty()) {
+            qWarning() << "8ball.txt is empty!";
+            sendServerMessage("8ball.txt is empty.");
+        }
+        else {
+            int answerindex = answers.size();
+            QString response = answers[(genRand(1, answerindex))];
+            QString sender_name = ooc_name;
+            QString sender_message = argv.join(" ");
+
+            sendServerMessageArea(sender_name + " asked the magic 8-ball " + sender_message + " and the answer is: " + response);
+        }
+
+    }
+
+}
+
 QStringList AOClient::buildAreaList(int area_idx)
 {
     QStringList entries;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1266,7 +1266,7 @@ void AOClient::cmd8Ball(int argc, QStringList argv)
             QString sender_name = ooc_name;
             QString sender_message = argv.join(" ");
 
-            sendServerMessageArea(sender_name + " asked the magic 8-ball " + sender_message + " and the answer is: " + response);
+            sendServerMessageArea(sender_name + " asked the magic 8-ball, \"" + sender_message + "\" and the answer is: " + response);
         }
 
     }


### PR DESCRIPTION
Answers are shown publicly. Adds config/text/8ball.txt to add, remove, or change 8ball answers. Answers are picked randomly from this file.

Screenshot:
![image](https://user-images.githubusercontent.com/58055358/113523225-1ff3a580-956c-11eb-972e-f3bedda74222.png)
