### PR TITLE
Add a blank space infront of additive messages, and prevent additive text between different characters

### DIFF
--- a/include/area_data.h
+++ b/include/area_data.h
@@ -272,6 +272,11 @@ class AreaData : public QObject {
      */
     EvidenceMod evi_mod;
     QMap<QString, QString> notecards;
+
+    /**
+     * @brief The last IC packet sent in an area.
+     */
+    QStringList last_ic_message;
 };
 
 #endif // AREA_DATA_H

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -24,7 +24,8 @@ AreaData::AreaData(QString p_name, int p_index) :
     locked(FREE),
     document("No document."),
     def_hp(10),
-    pro_hp(10)
+    pro_hp(10),
+    last_ic_message()
 {
     QStringList name_split = p_name.split(":");
     name_split.removeFirst();

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -168,6 +168,8 @@ void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket pa
 
     area->logger->logIC(this, &validated_packet);
     server->broadcast(validated_packet, current_area);
+    area->last_ic_message.clear();
+    area->last_ic_message.append(validated_packet.contents);
 }
 
 void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket packet)
@@ -601,6 +603,12 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
         int additive = incoming_args[24].toInt();
         if (additive != 0 && additive != 1)
             return invalid;
+        else if (area->last_ic_message.isEmpty()){
+            additive = 0;
+        }
+        else if (!(char_id == area->last_ic_message[8].toInt())) {
+            additive = 0;
+        }
         else if (additive == 1) {
             args[4].insert(0, " ");
         }

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -601,6 +601,9 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
         int additive = incoming_args[24].toInt();
         if (additive != 0 && additive != 1)
             return invalid;
+        else if (additive == 1) {
+            args[4].insert(0, " ");
+        }
         args.append(QString::number(additive));
 
         // effect


### PR DESCRIPTION
- adds a last_ic_message string list to areas which stores the last IC message sent