### PR TITLE
Use per-area antispam rather than per-client, allow for multiple subsequent blankposts

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -53,7 +53,7 @@ class AOClient : public QObject {
     AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent = nullptr, int user_id = 0)
         : QObject(parent), id(user_id), remote_ip(p_socket->peerAddress()), password(""),
           joined(false), current_area(0), current_char(""), socket(p_socket), server(p_server),
-          is_partial(false), last_wtce_time(0), last_message("") {};
+          is_partial(false), last_wtce_time(0) {};
 
     /**
       * @brief Destructor for the AOClient instance.

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -433,15 +433,15 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
 
     // message text
     QString incoming_msg = dezalgo(incoming_args[4].toString().trimmed());
-    if (incoming_msg == last_message)
+    if (!area->last_ic_message.isEmpty()
+            && incoming_msg == area->last_ic_message[4]
+            && incoming_msg != "")
         return invalid;
 
     if (incoming_msg == "" && area->blankposting_allowed == false) {
         sendServerMessage("Blankposting has been forbidden in this area.");
         return invalid;
     }
-
-    last_message = incoming_msg;
     args.append(incoming_msg);
 
     // side


### PR DESCRIPTION
This changes the built-in anti spam to work like its counterpart in tsuserver3, which should help contribute to a near-identical experience.