### PR TITLE
Add ability to force immediate text processing (/force_noint_pres) and command to toggle iniswapping (/allow_iniswap)

### DIFF
--- a/bin/config_sample/areas.ini
+++ b/bin/config_sample/areas.ini
@@ -4,6 +4,7 @@ protected_area=true
 iniswap_allowed=false
 evidence_mod=cm
 blankposting_allowed=true
+force_immediate=true
 
 [1:Courtroom 1]
 background=gs4
@@ -11,3 +12,4 @@ protected_area=false
 iniswap_allowed=true
 evidence_mod=ffa
 blankposting_allowed=true
+force_immediate=false

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1776,6 +1776,7 @@ class AOClient : public QObject {
         {"shake",              {ACLFlags.value("MUTE"),         1, &AOClient::cmdShake}},
         {"unshake",            {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnShake}},
         {"forceimmediate",     {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
+        {"force_noint_pres",   {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
     };
 
     /**

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1142,7 +1142,7 @@ class AOClient : public QObject {
      *
      * @iscommand
      */
-    void cmdAllow_Blankposting(int argc, QStringList argv);
+    void cmdAllowBlankposting(int argc, QStringList argv);
 
     ///@}
 
@@ -1528,6 +1528,15 @@ class AOClient : public QObject {
      */
     void cmdBanInfo(int argc, QStringList argv);
 
+    /**
+    * @brief Toggles immediate text processing in the current area.
+    *
+    * @details No arguments.
+    *
+    * @iscommand
+    */
+    void cmdForceImmediate(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1751,7 +1760,8 @@ class AOClient : public QObject {
         {"8ball",              {ACLFlags.value("NONE"),         1, &AOClient::cmd8Ball}},
         {"lm",                 {ACLFlags.value("MODCHAT"),      1, &AOClient::cmdLM}},
         {"judgelog",           {ACLFlags.value("CM"),           0, &AOClient::cmdJudgeLog}},
-        {"allow_blankposting", {ACLFlags.value("MODCHAT"),      0, &AOClient::cmdAllow_Blankposting}},
+        {"allowblankposting",  {ACLFlags.value("MODCHAT"),      0, &AOClient::cmdAllowBlankposting}},
+        {"allow_blankposting", {ACLFlags.value("MODCHAT"),      0, &AOClient::cmdAllowBlankposting}},
         {"gimp",               {ACLFlags.value("MUTE"),         1, &AOClient::cmdGimp}},
         {"ungimp",             {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnGimp}},
         {"baninfo",            {ACLFlags.value("BAN"),          1, &AOClient::cmdBanInfo}},
@@ -1765,6 +1775,7 @@ class AOClient : public QObject {
         {"undisemvowel",       {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnDisemvowel}},
         {"shake",              {ACLFlags.value("MUTE"),         1, &AOClient::cmdShake}},
         {"unshake",            {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnShake}},
+        {"forceimmediate",     {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
     };
 
     /**

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1537,6 +1537,15 @@ class AOClient : public QObject {
     */
     void cmdForceImmediate(int argc, QStringList argv);
 
+    /**
+    * @brief Toggles whether iniswaps are allowed in the current area.
+    *
+    * @details No arguments.
+    *
+    * @iscommand
+    */
+    void cmdAllowIniswap(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1777,6 +1786,8 @@ class AOClient : public QObject {
         {"unshake",            {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnShake}},
         {"forceimmediate",     {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
         {"force_noint_pres",   {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
+        {"allowiniswap",       {ACLFlags.value("CM"),           1, &AOClient::cmdAllowIniswap}},
+        {"allow_iniswap",      {ACLFlags.value("CM"),           1, &AOClient::cmdAllowIniswap}},
     };
 
     /**

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -344,6 +344,11 @@ class AreaData : public QObject {
      * @brief The value of logger in config.ini.
      */
     QString log_type;
+
+    /**
+     * @brief Whether or not to force immediate text processing in this area
+     */
+    bool force_immediate;
 };
 
 #endif // AREA_DATA_H

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -39,6 +39,7 @@ AreaData::AreaData(QString p_name, int p_index) :
     bg_locked = areas_ini.value("bg_locked", "false").toBool();
     QString configured_evi_mod = areas_ini.value("evidence_mod", "FFA").toString().toLower();
     blankposting_allowed = areas_ini.value("blankposting_allowed","true").toBool();
+    force_immediate = areas_ini.value("force_immediate", "false").toBool();
     areas_ini.endGroup();
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.beginGroup("Options");

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1529,6 +1529,14 @@ void AOClient::cmdForceImmediate(int argc, QStringList argv)
     sendServerMessage("Forced immediate text processing in this area is now " + state);
 }
 
+void AOClient::cmdAllowIniswap(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    area->iniswap_allowed = !area->iniswap_allowed;
+    QString state = area->iniswap_allowed ? "allowed." : "disallowed.";
+    sendServerMessage("Iniswapping in this area is now " + state);
+}
+
 QStringList AOClient::buildAreaList(int area_idx)
 {
     QStringList entries;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1276,7 +1276,7 @@ void AOClient::cmdJudgeLog(int argc, QStringList argv)
     }
 }
 
-void AOClient::cmdAllow_Blankposting(int argc, QStringList argv)
+void AOClient::cmdAllowBlankposting(int argc, QStringList argv)
 {
     QString sender_name = ooc_name;
     AreaData* area = server->areas[current_area];
@@ -1519,6 +1519,14 @@ void AOClient::cmdUnShake(int argc, QStringList argv)
         target->sendServerMessage("A moderator has unshook you! " + getReprimand(true));
     }
     target->is_shaken = false;
+}
+
+void AOClient::cmdForceImmediate(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    area->force_immediate = !area->force_immediate;
+    QString state = area->force_immediate ? "on." : "off.";
+    sendServerMessage("Forced immediate text processing in this area is now " + state);
 }
 
 QStringList AOClient::buildAreaList(int area_idx)

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -594,11 +594,13 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
         }
         args.append(other_flip);
 
-        // noninterrupting preanim
-        int ni_pa = incoming_args[18].toInt();
-        if (ni_pa != 1 && ni_pa != 0)
+        // immediate text processing
+        int immediate = incoming_args[18].toInt();
+        if (area->force_immediate)
+            immediate = 1;
+        if (immediate != 1 && immediate != 0)
             return invalid;
-        args.append(QString::number(ni_pa));
+        args.append(QString::number(immediate));
     }
 
     // 2.8 packet extensions


### PR DESCRIPTION
Note that "immediate text processing" and "non-interrupting pres" are the same concept, but the former description is preferred.