### PR TITLE
Add an AFK system, and /afk

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -55,6 +55,7 @@ class AOClient : public QObject {
           joined(false), current_area(0), current_char(""), socket(p_socket), server(p_server),
           is_partial(false), last_wtce_time(0) {
         afk_timer = new QTimer;
+        afk_timer->setSingleShot(true);
         connect(afk_timer, SIGNAL(timeout()), this, SLOT(onAfkTimeout()));
     };
 

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -53,7 +53,10 @@ class AOClient : public QObject {
     AOClient(Server* p_server, QTcpSocket* p_socket, QObject* parent = nullptr, int user_id = 0)
         : QObject(parent), id(user_id), remote_ip(p_socket->peerAddress()), password(""),
           joined(false), current_area(0), current_char(""), socket(p_socket), server(p_server),
-          is_partial(false), last_wtce_time(0) {};
+          is_partial(false), last_wtce_time(0) {
+        afk_timer = new QTimer;
+        connect(afk_timer, SIGNAL(timeout()), this, SLOT(onAfkTimeout()));
+    };
 
     /**
       * @brief Destructor for the AOClient instance.
@@ -233,6 +236,18 @@ class AOClient : public QObject {
      */
     bool is_gimped = false;
 
+    /**
+     * @brief If true, the client will be marked as AFK in /getarea. Automatically applied when a configurable
+     * amount of time has passed since the last interaction, or manually applied by /afk.
+     */
+    bool is_afk = false;
+
+    /**
+     * @brief Timer for tracking user interaction. Automatically restarted whenever a user interacts (i.e. sends any packet besides CH)
+     */
+    QTimer* afk_timer;
+
+
   public slots:
     /**
      * @brief A slot for when the client disconnects from the server.
@@ -260,6 +275,11 @@ class AOClient : public QObject {
      * @overload
      */
     void sendPacket(QString header);
+
+    /**
+     * @brief A slot for when the client's AFK timer runs out.
+     */
+    void onAfkTimeout();
 
   private:
     /**
@@ -1546,6 +1566,15 @@ class AOClient : public QObject {
     */
     void cmdAllowIniswap(int argc, QStringList argv);
 
+    /**
+    * @brief Toggles whether this client is considered AFK.
+    *
+    * @details No arguments.
+    *
+    * @iscommand
+    */
+    void cmdAfk(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1785,10 +1814,11 @@ class AOClient : public QObject {
         {"undisemvowel",       {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnDisemvowel}},
         {"shake",              {ACLFlags.value("MUTE"),         1, &AOClient::cmdShake}},
         {"unshake",            {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnShake}},
-        {"forceimmediate",     {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
-        {"force_noint_pres",   {ACLFlags.value("CM"),           1, &AOClient::cmdForceImmediate}},
-        {"allowiniswap",       {ACLFlags.value("CM"),           1, &AOClient::cmdAllowIniswap}},
-        {"allow_iniswap",      {ACLFlags.value("CM"),           1, &AOClient::cmdAllowIniswap}},
+        {"forceimmediate",     {ACLFlags.value("CM"),           0, &AOClient::cmdForceImmediate}},
+        {"force_noint_pres",   {ACLFlags.value("CM"),           0, &AOClient::cmdForceImmediate}},
+        {"allowiniswap",       {ACLFlags.value("CM"),           0, &AOClient::cmdAllowIniswap}},
+        {"allow_iniswap",      {ACLFlags.value("CM"),           0, &AOClient::cmdAllowIniswap}},
+        {"afk",                {ACLFlags.value("NONE"),         0, &AOClient::cmdAfk}},
     };
 
     /**

--- a/include/server.h
+++ b/include/server.h
@@ -233,6 +233,11 @@ class Server : public QObject {
     int max_dice;
 
     /**
+     * @brief The amount of time in seconds to wait before marking a user AFK.
+     */
+    int afk_timeout;
+
+    /**
      * @brief The server-wide global timer.
      */
     QTimer* timer;

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -324,7 +324,8 @@ Server* AOClient::getServer() { return server; }
 
 void AOClient::onAfkTimeout()
 {
-    sendServerMessage("You are now AFK.");
+    if (!is_afk)
+        sendServerMessage("You are now AFK.");
     is_afk = true;
 }
 

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -324,8 +324,9 @@ Server* AOClient::getServer() { return server; }
 
 void AOClient::onAfkTimeout()
 {
+    if (!is_afk)
+        sendServerMessage("You are now AFK.");
     is_afk = true;
-    sendServerMessage("You are now AFK.");
 }
 
 AOClient::~AOClient() {

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -326,7 +326,6 @@ void AOClient::onAfkTimeout()
 {
     sendServerMessage("You are now AFK.");
     is_afk = true;
-    afk_timer->stop();
 }
 
 AOClient::~AOClient() {

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -324,9 +324,9 @@ Server* AOClient::getServer() { return server; }
 
 void AOClient::onAfkTimeout()
 {
-    if (!is_afk)
-        sendServerMessage("You are now AFK.");
+    sendServerMessage("You are now AFK.");
     is_afk = true;
+    afk_timer->stop();
 }
 
 AOClient::~AOClient() {

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -77,6 +77,13 @@ void AOClient::handlePacket(AOPacket packet)
         return;
     }
 
+    if (packet.header != "CH") {
+        if (is_afk)
+            sendServerMessage("You are no longer AFK.");
+        is_afk = false;
+        afk_timer->start(server->afk_timeout * 1000);
+    }
+
     if (packet.contents.length() < info.minArgs) {
 #ifdef NET_DEBUG
         qDebug() << "Invalid packet args length. Minimum is" << info.minArgs << "but only" << packet.contents.length() << "were given.";
@@ -313,7 +320,13 @@ bool AOClient::checkAuth(unsigned long long acl_mask)
 
 QString AOClient::getIpid() { return ipid; }
 
-Server* AOClient::getServer() { return server; };
+Server* AOClient::getServer() { return server; }
+
+void AOClient::onAfkTimeout()
+{
+    is_afk = true;
+    sendServerMessage("You are now AFK.");
+}
 
 AOClient::~AOClient() {
     socket->deleteLater();

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1537,6 +1537,13 @@ void AOClient::cmdAllowIniswap(int argc, QStringList argv)
     sendServerMessage("Iniswapping in this area is now " + state);
 }
 
+void AOClient::cmdAfk(int argc, QStringList argv)
+{
+    is_afk = !is_afk;
+    QString state = is_afk ? "now" : "no longer";
+    sendServerMessage("You are " + state + " AFK.");
+}
+
 QStringList AOClient::buildAreaList(int area_idx)
 {
     QStringList entries;
@@ -1564,6 +1571,8 @@ QStringList AOClient::buildAreaList(int area_idx)
                 char_entry.insert(0, "[CM] ");
             if (authenticated)
                 char_entry += " (" + client->getIpid() + "): " + client->ooc_name;
+            if (client->is_afk)
+                char_entry += " [AFK]";
             entries.append(char_entry);
         }
     }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1539,9 +1539,8 @@ void AOClient::cmdAllowIniswap(int argc, QStringList argv)
 
 void AOClient::cmdAfk(int argc, QStringList argv)
 {
-    is_afk = !is_afk;
-    QString state = is_afk ? "now" : "no longer";
-    sendServerMessage("You are " + state + " AFK.");
+    is_afk = true;
+    sendServerMessage("You are now AFK.");
 }
 
 QStringList AOClient::buildAreaList(int area_idx)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -232,9 +232,13 @@ void Server::loadServerConfig()
     auth_type = config.value("auth","simple").toString();
     modpass = config.value("modpass","").toString();
     bool zalgo_tolerance_conversion_success;
-        zalgo_tolerance = config.value("zalgo_tolerance", "3").toInt(&zalgo_tolerance_conversion_success);
-        if (!zalgo_tolerance_conversion_success)
-            zalgo_tolerance = 3;
+    zalgo_tolerance = config.value("zalgo_tolerance", "3").toInt(&zalgo_tolerance_conversion_success);
+    if (!zalgo_tolerance_conversion_success)
+        zalgo_tolerance = 3;
+    bool afk_timeout_conversion_success;
+    afk_timeout = config.value("afk_timeout", "300").toInt(&afk_timeout_conversion_success);
+    if (!afk_timeout_conversion_success)
+        afk_timeout = 300;
     config.endGroup();
 
     //Load dice values


### PR DESCRIPTION
I didn't add /getafk because it's stupid and no one used it in tsuserver anyway.

Default timeout is 5 minutes, configurable via `afk_timeout` in config.ini. Time is in seconds.

Most people don't even know tsuserver *has* an AFK system, so akashi will notify you when you are considered AFK, and again when you are no longer AFK. You can force yourself to be considered AFK using /afk.

Also includes a fix for my last PR because I'm suffering from Dumb Bitch Disease and didn't notice it until I was neck deep in this one.