### PR TITLE
Move cmdAfk to messaging category

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1438,6 +1438,15 @@ class AOClient : public QObject {
      */
     void cmdUnShake(int argc, QStringList argv);
 
+    /**
+    * @brief Toggles whether this client is considered AFK.
+    *
+    * @details No arguments.
+    *
+    * @iscommand
+    */
+    void cmdAfk(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1586,16 +1595,6 @@ class AOClient : public QObject {
      * @iscommand
      */
     void cmdCurrentMusic(int argc, QStringList argv);
-
-
-    /**
-    * @brief Toggles whether this client is considered AFK.
-    *
-    * @details No arguments.
-    *
-    * @iscommand
-    */
-    void cmdAfk(int argc, QStringList argv);
 
     ///@}
 

--- a/src/commands/area.cpp
+++ b/src/commands/area.cpp
@@ -283,9 +283,3 @@ void AOClient::cmdJudgeLog(int argc, QStringList argv)
         sendServerMessage(filteredmessage);
     }
 }
-
-void AOClient::cmdAfk(int argc, QStringList argv)
-{
-    is_afk = true;
-    sendServerMessage("You are now AFK.");
-}

--- a/src/commands/messaging.cpp
+++ b/src/commands/messaging.cpp
@@ -274,3 +274,9 @@ void AOClient::cmdUnShake(int argc, QStringList argv)
     }
     target->is_shaken = false;
 }
+
+void AOClient::cmdAfk(int argc, QStringList argv)
+{
+    is_afk = true;
+    sendServerMessage("You are now AFK.");
+}


### PR DESCRIPTION
cmdAfk is a command that changes the clients status to AFK. As such, it belongs under the messaging category, which includes commands that handle a clients self-management.