### PR TITLE
Decode MS packet before testimony recorder regex

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1908,6 +1908,13 @@ class AOClient : public QObject {
      * @param action String containing the info that is being recorded.
      */
     void updateJudgeLog(AreaData* area, AOClient* client, QString action);
+
+    /**
+     * @brief A helper function for decoding AO encoding from a QString.
+     *
+     * @param incoming_message QString to be decoded.
+     */
+    QString decodeMessage(QString incoming_message);
 };
 
 #endif // AOCLIENT_H

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -724,8 +724,9 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
             area->statement = area->statement - 1;
             args = playTestimony();
         }
+        QString decoded_message = decodeMessage(args[4]); //Get rid of that pesky encoding first.
         QRegularExpression jump("(?<arrow>>)(?<int>[0,1,2,3,4,5,6,7,8,9]+)");
-        QRegularExpressionMatch match = jump.match(args[4]);
+        QRegularExpressionMatch match = jump.match(decoded_message);
         if (match.hasMatch()) {
             pos = "wit";
             area->statement = match.captured("int").toInt();
@@ -772,4 +773,13 @@ void AOClient::updateJudgeLog(AreaData* area, AOClient* client, QString action)
         area->judgelog.append(logmessage);
     }
     else area->judgelog.append(logmessage);
+}
+
+QString AOClient::decodeMessage(QString incoming_message)
+{
+   QString decoded_message = incoming_message.replace("<num>", "#")
+                                             .replace("<percent>", "%")
+                                             .replace("<dollar>", "$")
+                                             .replace("<and>", "&");
+    return decoded_message;
 }


### PR DESCRIPTION
- Fixes an issue with the testimony recorder checking for >[statement], where due to AO encoding, special characters would improperly match the regex. For example, "%[statement]" would become "\<percent>[statement]", thus matching against >[statement]. This commit decodes those characters first.

- Adds AOClient::decodeMessage() for decoding a QString.