### PR TITLE
Ensure the advertiser actually exists before connecting the reload signal/slot

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,10 @@ int main(int argc, char* argv[])
             }
 
             server = new Server(settings.port, settings.ws_port);
-            QObject::connect(server, &Server::reloadRequest, advertiser, &Advertiser::reloadRequested);
+
+            if (advertiser != nullptr) {
+                QObject::connect(server, &Server::reloadRequest, advertiser, &Advertiser::reloadRequested);
+            }
             server->start();
         }
     } else {


### PR DESCRIPTION
stops an error from appearing in the server console when advertiser is turned off in config.ini