### PR TITLE
Refactor AOClient::diceThrower() and add /togglemusic

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1665,6 +1665,13 @@ class AOClient : public QObject {
      */
     void cmdCurrentMusic(int argc, QStringList argv);
 
+    /**
+     * @brief Toggles music playing in the current area.
+     *
+     * @details No arguments.
+     */
+    void cmdToggleMusic(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1936,7 +1943,8 @@ class AOClient : public QObject {
         {"block_dj",           {ACLFlags.value("MUTE"),         1, &AOClient::cmdBlockDj}},
         {"unblockdj",          {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnBlockDj}},
         {"unblock_dj",         {ACLFlags.value("MUTE"),         1, &AOClient::cmdUnBlockDj}},
-        {"charselect",         {ACLFlags.value("NONE"),         0, &AOClient::cmdCharSelect}}
+        {"charselect",         {ACLFlags.value("NONE"),         0, &AOClient::cmdCharSelect}},
+        {"togglemusic",        {ACLFlags.value("CM"),           0, &AOClient::cmdToggleMusic}},
     };
 
     /**

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -1735,7 +1735,7 @@ class AOClient : public QObject {
      * See @ref commandArgv "CommandInfo's `action`'s second parameter".
      * @param Type The type of the dice-rolling being done.
      */
-    void diceThrower(int argc, QStringList argv, RollType Type);
+    void diceThrower(int argc, QStringList argv, bool p_roll);
 
     /**
      * @brief Interprets an expression of time into amount of seconds.

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -327,17 +327,6 @@ class AOClient : public QObject {
     };
 
     /**
-     * @brief Used for the common parts of the dice rolling commands, to determine where the function should go after the common functionality.
-     *
-     * @see AOClient::diceThrower
-     */
-    enum RollType {
-        ROLL, //!< The roll is a simple numerical roll, should be announced in the area.
-        ROLLP, //!< The roll is a numerical roll, but private, the result should only be told to the caller.
-        ROLLA //!< The roll is an ability roll, the values must be read out of the ability die configs.
-    };
-
-    /**
      * @brief Handles an incoming packet, checking for authorisation and minimum argument count.
      *
      * @param packet The incoming packet.
@@ -1190,7 +1179,7 @@ class AOClient : public QObject {
     void cmdFlip(int argc, QStringList argv);
 
     /**
-     * @brief Rolls dice, summing the results.
+     * @brief Rolls dice and sends the results.
      *
      * @details The first argument is the **amount of faces** each die should have.
      * The second argument is the **amount of dice** that should be rolled.
@@ -1747,18 +1736,13 @@ class AOClient : public QObject {
     int genRand(int min, int max);
 
     /**
-     * @brief A convenience function unifying the various dice-rolling methods.
+     * @brief A convenience function for rolling dice.
      *
-     * @internal
-     *  Babby's first code. <3
-     * @endinternal
+     * @param argc The amount of arguments.
      *
-     * @param argc The amount of arguments arriving to the function through a command call,
-     * equivalent to `argv.size()`.
-     * See @ref commandArgc "CommandInfo's `action`'s first parameter".
-     * @param argv The list of arguments passed to the function through a command call.
-     * See @ref commandArgv "CommandInfo's `action`'s second parameter".
-     * @param Type The type of the dice-rolling being done.
+     * @param argv Stringlist of the arguments given by the client.
+     *
+     * @param p_roll Bool to determine of a roll is private or not.
      */
     void diceThrower(int argc, QStringList argv, bool p_roll);
 

--- a/include/area_data.h
+++ b/include/area_data.h
@@ -346,9 +346,14 @@ class AreaData : public QObject {
     QString log_type;
 
     /**
-     * @brief Whether or not to force immediate text processing in this area
+     * @brief Whether or not to force immediate text processing in this area.
      */
     bool force_immediate;
+
+    /**
+     * @brief Whether or not music is allowed in this area. If false, only CMs can change the music.
+     */
+    bool toggle_music;
 };
 
 #endif // AREA_DATA_H

--- a/include/server.h
+++ b/include/server.h
@@ -225,7 +225,7 @@ class Server : public QObject {
     /**
      * @brief The highest value dice can have.
      */
-    uint dice_value;
+    int dice_value;
 
     /**
      * @brief The max amount of dice that can be rolled at once.

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -40,6 +40,7 @@ AreaData::AreaData(QString p_name, int p_index) :
     QString configured_evi_mod = areas_ini.value("evidence_mod", "FFA").toString().toLower();
     blankposting_allowed = areas_ini.value("blankposting_allowed","true").toBool();
     force_immediate = areas_ini.value("force_immediate", "false").toBool();
+    toggle_music = areas_ini.value("toggle_music", "true").toBool();
     areas_ini.endGroup();
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.beginGroup("Options");

--- a/src/commands/command_helper.cpp
+++ b/src/commands/command_helper.cpp
@@ -74,62 +74,24 @@ int AOClient::genRand(int min, int max)
 #endif
 }
 
-void AOClient::diceThrower(int argc, QStringList argv, RollType type)
+void AOClient::diceThrower(int argc, QStringList argv, bool p_roll)
 {
-    QString sender_name = ooc_name;
-    int max_value = server->dice_value;
-    int max_dice = server->max_dice;
-    int bounded_value;
-    int bounded_amount;
-    QString dice_results;
-
-    if (argc == 0) {
-        dice_results = QString::number(genRand(1, 6)); // Self-explanatory
+    int sides = 6;
+    int dice = 1;
+    QStringList results;
+    if (argc >= 1)
+        sides = qBound(1, argv[0].toInt(), server->dice_value);
+    if (argc == 2)
+        dice = qBound(1, argv[1].toInt(), server->max_dice);
+    for (int i = 1; i <= dice; i++) {
+        results.append(QString::number(AOClient::genRand(1, sides)));
     }
-    else if (argc == 1) {
-        bounded_value = qBound(1, argv[0].toInt(), max_value); // faces, max faces
-        dice_results = QString::number(genRand(1, bounded_value));
+    QString total_results = results.join(" ");
+    if (p_roll) {
+        sendServerMessage("You rolled a " + QString::number(dice) + "d" + QString::number(sides) + ". Results: " + total_results);
+        return;
     }
-    else if (argc == 2) {
-        bounded_value = qBound(1, argv[0].toInt(), max_value); // 1, faces, max faces
-        bounded_amount = qBound(1, argv[1].toInt(), max_dice); // 1, amount, max amount
-
-        for (int i = 1; i <= bounded_amount ; i++) // Loop as multiple dices are thrown
-        {
-            QString dice_result = QString::number(genRand(1, bounded_value));
-            if (i == bounded_amount) {
-                dice_results = dice_results.append(dice_result);
-            }
-            else {
-                dice_results = dice_results.append(dice_result + ",");
-            }
-        }
-    }
-    // Switch to change message behaviour, isEmpty check or the entire server crashes due to an out of range issue in the QStringList
-    switch(type)
-    {
-        case ROLL:
-        if (argv.isEmpty()) {
-            sendServerMessageArea(sender_name + " rolled " + dice_results + " out of 6");
-        }
-        else {
-            sendServerMessageArea(sender_name + " rolled " + dice_results + " out of " + QString::number(bounded_value));
-        }
-        break;
-        case ROLLP:
-        if (argv.isEmpty()) {
-            sendServerMessage(sender_name + " rolled " + dice_results + " out of 6");
-            sendServerMessageArea((sender_name + " rolled in secret."));
-        }
-        else {
-            sendServerMessageArea(sender_name + " rolled " + dice_results + " out of " + QString::number(bounded_value));
-            sendServerMessageArea((sender_name + " rolled in secret."));
-        }
-        break;
-        case ROLLA:
-        //Not implemented yet
-        default : break;
-    }
+    sendServerMessageArea(ooc_name + " rolled a " + QString::number(dice) + "d" + QString::number(sides) + ". Results: " + total_results);
 }
 
 QString AOClient::getAreaTimer(int area_idx, int timer_idx)

--- a/src/commands/music.cpp
+++ b/src/commands/music.cpp
@@ -82,3 +82,11 @@ void AOClient::cmdUnBlockDj(int argc, QStringList argv)
     }
     target->is_dj_blocked = false;
 }
+
+void AOClient::cmdToggleMusic(int argc, QStringList argv)
+{
+    AreaData* area = server->areas[current_area];
+    area->toggle_music = !area->toggle_music;
+    QString state = area->toggle_music ? "allowed." : "disallowed.";
+    sendServerMessage("Music in this area is now " + state);
+}

--- a/src/commands/roleplay.cpp
+++ b/src/commands/roleplay.cpp
@@ -30,12 +30,12 @@ void AOClient::cmdFlip(int argc, QStringList argv)
 
 void AOClient::cmdRoll(int argc, QStringList argv)
 {
-    diceThrower(argc, argv, RollType::ROLL);
+    diceThrower(argc, argv, false);
 }
 
 void AOClient::cmdRollP(int argc, QStringList argv)
 {
-    diceThrower(argc, argv, RollType::ROLLP);
+    diceThrower(argc, argv, true);
 }
 
 void AOClient::cmdTimer(int argc, QStringList argv)

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -225,6 +225,10 @@ void AOClient::pktChangeMusic(AreaData* area, int argc, QStringList argv, AOPack
                 sendServerMessage("You are blocked from changing the music.");
                 return;
             }
+            if (!area->toggle_music && !checkAuth(ACLFlags.value("CM"))) {
+                sendServerMessage("Music is disabled in this area.");
+                return;
+            }
             QString effects;
             if (argc >= 4)
                 effects = argv[3];


### PR DESCRIPTION
- Refactors diceThrower(), cleaning up the code and improving the implementation. Cleans up the documentation and removes the obsolete enum RollType.
- Adds /togglemusic for toggling music playing in an area. CMed clients can still play music like normal.
- Adds toggle_music to areas and areas.ini, for setting the default value for music playing in an area. Defaults to true.