### PR TITLE
Add a size limit to packets and a configurable maximum character limit for messages.

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -18,6 +18,7 @@ logbuffer=500
 logging=modcall
 maximum_statements=10
 multiclient_limit=15
+maximum_characters=256
 
 [Dice]
 max_value=100

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -2049,6 +2049,11 @@ class AOClient : public QObject {
      * @param incoming_message QString to be decoded.
      */
     QString decodeMessage(QString incoming_message);
+
+    /**
+     * @brief The size, in bytes, of the last data the client sent to the server.
+     */
+    int last_read;
 };
 
 #endif // AOCLIENT_H

--- a/include/server.h
+++ b/include/server.h
@@ -286,6 +286,11 @@ class Server : public QObject {
      */
     int multiclient_limit;
 
+    /**
+     * @brief Integer representing the maximum amount of characters an IC or OOC message can contain.
+     */
+    int max_chars;
+
   public slots:
     /**
      * @brief Handles a new connection.

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -73,6 +73,10 @@ void AOClient::handlePacket(AOPacket packet)
     AreaData* area = server->areas[current_area];
     PacketInfo info = packets.value(packet.header, {false, 0, &AOClient::pktDefault});
 
+    if (packet.contents.join("").size() > 16384) {
+        return;
+    }
+
     if (!checkAuth(info.acl_mask)) {
         return;
     }

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -19,7 +19,12 @@
 
 void AOClient::clientData()
 {
+    if (last_read + socket->bytesAvailable() > 30720) { // Client can send a max of 30KB to the server over two sequential reads
+        socket->close();
+    }
+
     QString data = QString::fromUtf8(socket->readAll());
+    last_read = data.size();
 
     if (is_partial) {
         data = partial_packet + data;

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -41,6 +41,7 @@ AreaData::AreaData(QString p_name, int p_index) :
     blankposting_allowed = areas_ini.value("blankposting_allowed","true").toBool();
     force_immediate = areas_ini.value("force_immediate", "false").toBool();
     toggle_music = areas_ini.value("toggle_music", "true").toBool();
+    showname_allowed = areas_ini.value("shownames_allowed", "true").toBool();
     areas_ini.endGroup();
     QSettings config_ini("config/config.ini", QSettings::IniFormat);
     config_ini.beginGroup("Options");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -283,6 +283,10 @@ void Server::loadServerConfig()
     multiclient_limit = config.value("multiclient_limit", "15").toInt(&multiclient_limit_conversion_success);
     if (!multiclient_limit_conversion_success)
         multiclient_limit = 15;
+    bool max_char_conversion_success;
+    max_chars = config.value("maximum_characters", "256").toInt(&max_char_conversion_success);
+    if (!max_char_conversion_success)
+        max_chars = 256;
     config.endGroup();
 
     //Load dice values


### PR DESCRIPTION
- Limits packets to under 16KB.
- Adds a configurable option to config.ini for setting the maximum amount of characters in an IC/OOC message.
- Limits the size of OOC names to 30 chars.
   - The client already limits this, but this is an added precaution.
- Limits the length of shownames to 30 chars.
- Implements shownames_allowed for areas, for toggling whether shownames are allowed for messages in that area.
- Limits the amount of data the client can send to the server to 30KB over two sequential reads.

Resolves #98 