### PR TITLE
Change /login to use a "prompt" based system

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -686,11 +686,9 @@ class AOClient : public QObject {
     ///@{
 
     /**
-     * @brief Logs the user in as a moderator.
+     * @brief Sets the client to be in the process of logging in, setting is_logging_in to **true**.
      *
-     * @details If the authorisation type is `"simple"`, then this command expects one argument, the **global moderator password**.
-     *
-     * If the authorisation type is `"advanced"`, then it requires two arguments, the **moderator's username** and the **matching password**.
+     * @details No arguments.
      *
      * @iscommand
      */

--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -282,6 +282,11 @@ class AOClient : public QObject {
      */
     bool testimony_saving = false;
 
+    /**
+     * @brief If true, the client's next OOC message will be interpreted as a moderator login.
+     */
+    bool is_logging_in = false;
+
   public slots:
     /**
      * @brief A slot for when the client disconnects from the server.
@@ -1869,7 +1874,7 @@ class AOClient : public QObject {
       * See @ref CommandInfo "the type's documentation" for more details.
       */
     const QMap<QString, CommandInfo> commands {
-        {"login",              {ACLFlags.value("NONE"),         1, &AOClient::cmdLogin}},
+        {"login",              {ACLFlags.value("NONE"),         0, &AOClient::cmdLogin}},
         {"getareas",           {ACLFlags.value("NONE"),         0, &AOClient::cmdGetAreas}},
         {"getarea",            {ACLFlags.value("NONE"),         0, &AOClient::cmdGetArea}},
         {"ban",                {ACLFlags.value("BAN"),          2, &AOClient::cmdBan}},
@@ -2054,6 +2059,13 @@ class AOClient : public QObject {
      * @brief The size, in bytes, of the last data the client sent to the server.
      */
     int last_read;
+
+    /**
+     * @brief A helper function for logging in a client as moderator.
+     *
+     * @param message The OOC message the client has sent.
+     */
+    void loginAttempt(QString message);
 };
 
 #endif // AOCLIENT_H

--- a/src/commands/authentication.cpp
+++ b/src/commands/authentication.cpp
@@ -26,46 +26,21 @@ void AOClient::cmdLogin(int argc, QStringList argv)
         sendServerMessage("You are already logged in!");
         return;
     }
-
     if (server->auth_type == "simple") {
         if (server->modpass == "") {
-            sendServerMessage("No modpass is set! Please set a modpass before authenticating.");
-        }
-        else if(argv[0] == server->modpass) {
-            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
-            sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
-            authenticated = true;
-        }
-        else {
-            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
-            sendServerMessage("Incorrect password.");
-        }
-        server->areas.value(current_area)->logger->logLogin(this, authenticated, "moderator");
-    }
-    else if (server->auth_type == "advanced") {
-        if (argc < 2) {
-            sendServerMessage("You must specify a username and a password");
+            sendServerMessage("No modpass is set. Please set a modpass before logging in.");
             return;
         }
-        QString username = argv[0];
-        QString password = argv[1];
-        if (server->db_manager->authenticate(username, password)) {
-            moderator_name = username;
-            authenticated = true;
-            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
-            if (version.release <= 2 && version.major <= 9 && version.minor <= 0)
-                sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
-            sendServerMessage("Welcome, " + username);
-        }
         else {
-            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
-            sendServerMessage("Incorrect password.");
+            sendServerMessage("Entering login prompt.\nPlease enter the server modpass.");
+            is_logging_in = true;
+            return;
         }
-        server->areas.value(current_area)->logger->logLogin(this, authenticated, username);
     }
-    else {
-        qWarning() << "config.ini has an unrecognized auth_type!";
-        sendServerMessage("Config.ini contains an invalid auth_type, please check your config.");
+    else if (server->auth_type == "advanced") {
+        sendServerMessage("Entering login prompt.\nPlease enter your username and password.");
+        is_logging_in = true;
+        return;
     }
 }
 

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -185,6 +185,11 @@ void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket p
         sendServerMessage("Your name is too long! Please limit it to under 30 characters.");
         return;
     }
+
+    if (is_logging_in) {
+        loginAttempt(argv[1]);
+        return;
+    }
     
     QString message = dezalgo(argv[1]);
     if (message.length() == 0 || message.length() > server->max_chars)
@@ -813,4 +818,51 @@ QString AOClient::decodeMessage(QString incoming_message)
                                              .replace("<dollar>", "$")
                                              .replace("<and>", "&");
     return decoded_message;
+}
+
+void AOClient::loginAttempt(QString message)
+{
+    if (server->auth_type == "simple") {
+        if (message == server->modpass) {
+            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
+            sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
+            authenticated = true;
+        }
+        else {
+            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
+            sendServerMessage("Incorrect password.");
+        }
+        server->areas.value(current_area)->logger->logLogin(this, authenticated, "moderator");
+    }
+    else if (server->auth_type == "advanced") {
+        QStringList login = message.split(" ");
+        if (login.size() < 2) {
+            sendServerMessage("You must specify a username and a password");
+            sendServerMessage("Exiting login prompt.");
+            is_logging_in = false;
+            return;
+        }
+        QString username = login[0];
+        QString password = login[1];
+        if (server->db_manager->authenticate(username, password)) {
+            moderator_name = username;
+            authenticated = true;
+            sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
+            if (version.release <= 2 && version.major <= 9 && version.minor <= 0)
+                sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
+            sendServerMessage("Welcome, " + username);
+        }
+        else {
+            sendPacket("AUTH", {"0"}); // Client: "Login unsuccessful."
+            sendServerMessage("Incorrect password.");
+        }
+        server->areas.value(current_area)->logger->logLogin(this, authenticated, username);
+    }
+    else {
+            qWarning() << "config.ini has an unrecognized auth_type!";
+            sendServerMessage("Config.ini contains an invalid auth_type, please check your config.");
+        }
+    sendServerMessage("Exiting login prompt.");
+    is_logging_in = false;
+    return;
 }


### PR DESCRIPTION
This PR changes /login to no longer take command arguments. Instead, upon sending /login, you will enter an interactive "prompt", where your next OOC message will be interpreted as your login attempt (and will not be shown to other users). This prevents a typo from accidentally broadcasting your credentials to the entire area.

- Changes /login to take no command arguments, /login now sets a client state "is_logging_in".
- pktOocChat will now intercept a client's OOC message if they have this client state, and will interpret that as a moderator login.
- Adds the helper function loginAttempt() for handling moderator logins.