### PR TITLE
Fix Dezalgo

### DIFF
--- a/include/config_manager.h
+++ b/include/config_manager.h
@@ -68,7 +68,6 @@ class ConfigManager {
         QString name; //!< The name of the server as advertised on the server browser.
         QString description; //!< The description of the server as advertised on the server browser.
         bool advertise_server; //!< The server will only be announced to the master server (and thus appear on the master server list) if this is true.
-        int zalgo_tolerance; //!< The amount of subscripts zalgo is stripped by.
     };
 
     /**

--- a/include/server.h
+++ b/include/server.h
@@ -218,11 +218,6 @@ class Server : public QObject {
     QString modpass;
 
     /**
-     * @brief The amount of subscripts zalgo is stripped by.
-     */
-    int zalgo_tolerance;
-
-    /**
      * @brief The highest value dice can have.
      */
     int dice_value;

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -144,7 +144,6 @@ bool ConfigManager::loadServerSettings(server_settings* settings)
     bool port_conversion_success;
     bool ws_port_conversion_success;
     bool local_port_conversion_success;
-    bool zalgo_tolerance_conversion_success;
     config.beginGroup("Options");
     settings->ms_ip =
         config.value("ms_ip", "master.aceattorneyonline.com").toString();
@@ -158,8 +157,6 @@ bool ConfigManager::loadServerSettings(server_settings* settings)
     settings->description =
         config.value("server_description", "This is my flashy new server")
             .toString();
-    settings->zalgo_tolerance =
-        config.value("zalgo_tolerance", "3").toInt(&zalgo_tolerance_conversion_success);
     config.endGroup();
     if (!port_conversion_success || !ws_port_conversion_success ||
         !local_port_conversion_success) {

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -109,7 +109,7 @@ void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPack
     sendPacket("OPPASS", {"DEADBEEF"});
     sendPacket("DONE");
     sendPacket("BN", {area->background});
-  
+
     sendServerMessage("=== MOTD ===\r\n" + server->MOTD + "\r\n=============");
 
     fullArup(); // Give client all the area data
@@ -185,7 +185,7 @@ void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket p
         sendServerMessage("Your name is too long! Please limit it to under 30 characters.");
         return;
     }
-    
+
     QString message = dezalgo(argv[1]);
     if (message.length() == 0 || message.length() > server->max_chars)
         return;
@@ -770,7 +770,7 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
 
 QString AOClient::dezalgo(QString p_text)
 {
-    QRegExp rxp("([\u0300-\u036f\u1ab0-\u1aff\u1dc0-\u1dff\u20d0-\u20ff\ufe20-\ufe2f\u115f\u1160\u3164]{" + QRegExp::escape(QString::number(server->zalgo_tolerance)) + ",})");
+    QRegularExpression rxp("([̴̵̶̷̸̡̢̧̨̛̖̗̘̙̜̝̞̟̠̣̤̥̦̩̪̫̬̭̮̯̰̱̲̳̹̺̻̼͇͈͉͍͎̀́̂̃̄̅̆̇̈̉̊̋̌̍̎̏̐̑̒̓̔̽̾̿̀́͂̓̈́͆͊͋͌̕̚ͅ͏͓͔͕͖͙͚͐͑͒͗͛ͣͤͥͦͧͨͩͪͫͬͭͮͯ͘͜͟͢͝͞͠͡])");
     QString filtered = p_text.replace(rxp, "");
     return filtered;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -267,10 +267,6 @@ void Server::loadServerConfig()
     MOTD = config.value("motd","MOTD is not set.").toString();
     auth_type = config.value("auth","simple").toString();
     modpass = config.value("modpass","").toString();
-    bool zalgo_tolerance_conversion_success;
-    zalgo_tolerance = config.value("zalgo_tolerance", "3").toInt(&zalgo_tolerance_conversion_success);
-    if (!zalgo_tolerance_conversion_success)
-        zalgo_tolerance = 3;
     bool maximum_statements_conversion_success;
     maximum_statements = config.value("maximum_statements", "10").toInt(&maximum_statements_conversion_success);
     if (!maximum_statements_conversion_success)


### PR DESCRIPTION
Replaces the dezalgo regex with a possibly more sensible one. Removes most of the unicode characters used by zalgo text without breaking languages. Works pretty well in testing. Removes zalgo_tolerance because it doesn't really work with this system and is unnecessary.

Also fixes the weird issues with question marks occasionally being stripped by dezalgo.