### PR TITLE
Add first person mode

### DIFF
--- a/include/aoclient.h
+++ b/include/aoclient.h
@@ -162,6 +162,13 @@ class AOClient : public QObject {
     bool global_enabled = true;
 
     /**
+     * @brief If true, the client's messages will be sent in first-person mode.
+     *
+     * @see AOClient::cmdFirstPerson
+     */
+    bool first_person = false;
+
+    /**
      * @brief If true, the client may not use in-character chat.
      */
     bool is_muted = false;
@@ -1528,6 +1535,15 @@ class AOClient : public QObject {
      */
     void cmdS(int argc, QStringList argv);
 
+    /**
+     * @brief Toggle whether the client's messages will be sent in first person mode.
+     *
+     * @details No arguments.
+     *
+     * @iscommand
+     */
+    void cmdFirstPerson(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -1983,7 +1999,8 @@ class AOClient : public QObject {
         {"charselect",         {ACLFlags.value("NONE"),         0, &AOClient::cmdCharSelect}},
         {"togglemusic",        {ACLFlags.value("CM"),           0, &AOClient::cmdToggleMusic}},
         {"a",                  {ACLFlags.value("NONE"),         2, &AOClient::cmdA}},
-        {"s",                  {ACLFlags.value("NONE"),         0, &AOClient::cmdS}}
+        {"s",                  {ACLFlags.value("NONE"),         0, &AOClient::cmdS}},
+        {"firstperson",        {ACLFlags.value("NONE"),         0, &AOClient::cmdFirstPerson}},
     };
 
     /**

--- a/src/commands/area.cpp
+++ b/src/commands/area.cpp
@@ -260,14 +260,14 @@ void AOClient::cmdBgLock(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
     area->bg_locked = true;
-    server->broadcast(AOPacket("CT", {"Server", current_char + " locked the background.", "1"}), current_area);
+    server->broadcast(AOPacket("CT", {server->server_name, current_char + " locked the background.", "1"}), current_area);
 }
 
 void AOClient::cmdBgUnlock(int argc, QStringList argv)
 {
     AreaData* area = server->areas[current_area];
     area->bg_locked = false;
-    server->broadcast(AOPacket("CT", {"Server", current_char + " unlocked the background.", "1"}), current_area);
+    server->broadcast(AOPacket("CT", {server->server_name, current_char + " unlocked the background.", "1"}), current_area);
 }
 
 void AOClient::cmdStatus(int argc, QStringList argv)
@@ -291,7 +291,7 @@ void AOClient::cmdStatus(int argc, QStringList argv)
         return;
     }
     arup(ARUPType::STATUS, true);
-    sendServerMessageArea(ooc_name + " changed status to " + arg);
+    server->broadcast(AOPacket("CT", {server->server_name, current_char + " changed status to " + arg.toUpper(), "1"}), current_area);
 }
 
 void AOClient::cmdJudgeLog(int argc, QStringList argv)

--- a/src/commands/messaging.cpp
+++ b/src/commands/messaging.cpp
@@ -445,3 +445,10 @@ void AOClient::cmdS(int argc, QStringList argv)
             server->broadcast(AOPacket("CT", {"[CM]" + sender_name, ooc_message}), i);
     }
 }
+
+void AOClient::cmdFirstPerson(int argc, QStringList argv)
+{
+    first_person = !first_person;
+    QString str_en = first_person ? "enabled" : "disabled";
+    sendServerMessage("First person mode " + str_en + ".");
+}

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -566,7 +566,7 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     args.append(QString::number(emote_mod));
 
     // char id
-    if (incoming_args[8].toInt() != char_id)
+    if (incoming_args[8].toInt() != char_id && incoming_args[8].toInt() != -1)
         return invalid;
     if (first_person)
         args.append("-1"); // messages with a cid of -1 don't update the viewport

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -568,7 +568,10 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     // char id
     if (incoming_args[8].toInt() != char_id)
         return invalid;
-    args.append(incoming_args[8].toString());
+    if (first_person)
+        args.append("-1"); // messages with a cid of -1 don't update the viewport
+    else
+        args.append(incoming_args[8].toString());
 
     // sfx delay
     args.append(incoming_args[9].toString());

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -502,6 +502,8 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
 
     // emote
     emote = incoming_args[3].toString();
+    if (first_person)
+        emote = "";
     args.append(emote);
 
     // message text
@@ -566,12 +568,9 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     args.append(QString::number(emote_mod));
 
     // char id
-    if (incoming_args[8].toInt() != char_id && incoming_args[8].toInt() != -1)
+    if (incoming_args[8].toInt() != char_id)
         return invalid;
-    if (first_person)
-        args.append("-1"); // messages with a cid of -1 don't update the viewport
-    else
-        args.append(incoming_args[8].toString());
+    args.append(incoming_args[8].toString());
 
     // sfx delay
     args.append(incoming_args[9].toString());


### PR DESCRIPTION
For investigation segments and lobby scenes, the lead defense may want to enter first person mode to more accurately reflect the Ace Attorney games. In 2.9.1 onwards, an IC message with an empty emote will cause the viewport to not update, which creates the "first person" effect.