### PR TITLE
Set a floodguard between IC messages

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -19,6 +19,7 @@ logging=modcall
 maximum_statements=10
 multiclient_limit=15
 maximum_characters=256
+message_floodguard=250
 
 [Dice]
 max_value=100

--- a/include/server.h
+++ b/include/server.h
@@ -303,6 +303,21 @@ class Server : public QObject {
      */
     int max_chars;
 
+    /**
+     * @brief Timer until the next IC message can be sent.
+     */
+    QTimer next_message_timer;
+
+    /**
+     * @brief If false, IC messages will be rejected.
+     */
+    bool can_send_ic_messages = true;
+
+    /**
+     * @brief The minimum time between IC messages, in milliseconds.
+     */
+    int message_floodguard;
+
   public slots:
     /**
      * @brief Handles a new connection.
@@ -311,6 +326,13 @@ class Server : public QObject {
      * checks if the client is banned.
      */
     void clientConnected();
+
+    /**
+     * @brief Sets #can_send_messages to true.
+     *
+     * @details Called whenever #next_message_timer reaches 0.
+     */
+    void allowMessage();
 
   signals:
 

--- a/src/packets.cpp
+++ b/src/packets.cpp
@@ -157,6 +157,10 @@ void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket pa
         return;
     }
 
+    if (!server->can_send_ic_messages) {
+        return;
+    }
+
     AOPacket validated_packet = validateIcPacket(packet);
     if (validated_packet.header == "INVALID")
         return;
@@ -168,6 +172,9 @@ void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket pa
     server->broadcast(validated_packet, current_area);
     area->last_ic_message.clear();
     area->last_ic_message.append(validated_packet.contents);
+
+    server->can_send_ic_messages = false;
+    server->next_message_timer.start(server->message_floodguard);
 }
 
 void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket packet)
@@ -884,3 +891,4 @@ void AOClient::loginAttempt(QString message)
     is_logging_in = false;
     return;
 }
+

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -104,6 +104,7 @@ void Server::start()
         QString area_name = raw_area_names[i];
         areas.insert(i, new AreaData(area_name, i));
     }
+    connect(&next_message_timer, SIGNAL(timeout()), this, SLOT(allowMessage()));
 }
 
 void Server::clientConnected()
@@ -290,6 +291,10 @@ void Server::loadServerConfig()
     max_chars = config.value("maximum_characters", "256").toInt(&max_char_conversion_success);
     if (!max_char_conversion_success)
         max_chars = 256;
+    bool message_floodguard_conversion_success;
+    message_floodguard = config.value("message_floodguard", "250").toInt(&message_floodguard_conversion_success);
+    if (!message_floodguard_conversion_success)
+        message_floodguard = 30;
     config.endGroup();
 
     //Load dice values
@@ -304,6 +309,11 @@ void Server::loadServerConfig()
     webhook_url = config.value("webhook_url", "Your webhook url here.").toString();
     webhook_sendfile = config.value("webhook_sendfile", false).toBool();
     config.endGroup();
+}
+
+void Server::allowMessage()
+{
+    can_send_ic_messages = true;
 }
 
 Server::~Server()


### PR DESCRIPTION
- Adds a timer to run between IC messages, preventing IC messages from being sent until it times out.
- The duration of this timer is configurable.