### PR TITLE
Add a moderator field to the ban table, add DB versioning, and fix /baninfo and /bans

### DIFF
--- a/include/db_manager.h
+++ b/include/db_manager.h
@@ -129,6 +129,7 @@ public:
         QString reason; //!< The reason given for the ban by the moderator who registered it.
         long long duration; //!< The duration of the ban, in seconds.
         int id; //!< The unique ID of the ban.
+        QString moderator; //!< The moderator who issued the ban.
     };
 
     /**

--- a/include/db_manager.h
+++ b/include/db_manager.h
@@ -18,6 +18,8 @@
 #ifndef BAN_MANAGER_H
 #define BAN_MANAGER_H
 
+#define DB_VERSION 1
+
 #include <QDebug>
 #include <QDateTime>
 #include <QHostAddress>
@@ -268,6 +270,25 @@ private:
      * @brief The backing database that stores user details.
      */
     QSqlDatabase db;
+
+    /**
+     * @brief The current server DB version.
+     */
+    int db_version;
+
+    /**
+     * @brief checkVersion Checks the current server DB version.
+     *
+     * @return Returns the server DB version.
+     */
+    int checkVersion();
+
+    /**
+     * @brief updateDB Updates the server DB to the latest version.
+     *
+     * @param current_version The current DB version.
+     */
+    void updateDB(int current_version);
 };
 
 #endif // BAN_MANAGER_H

--- a/src/commands/moderation.cpp
+++ b/src/commands/moderation.cpp
@@ -22,38 +22,24 @@
 
 void AOClient::cmdBan(int argc, QStringList argv)
 {
-    QString args_str = argv[1];
-    if (argc > 2) {
-        for (int i = 2; i < argc; i++)
+    QString args_str = argv[2];
+    if (argc > 3) {
+        for (int i = 3; i < argc; i++)
             args_str += " " + argv[i];
     }
 
     DBManager::BanInfo ban;
 
-    QRegularExpression quoteMatcher("['\"](.+?)[\"']");
-    QRegularExpressionMatchIterator matches = quoteMatcher.globalMatch(args_str);
-    QList<QString> unquoted_args;
-    while (matches.hasNext()) {
-        QRegularExpressionMatch match = matches.next();
-        unquoted_args.append(match.captured(1));
-    }
-
-    QString duration = "perma";
-
-    if (unquoted_args.length() < 1) {
-        sendServerMessage("Invalid syntax. Usage:\n/ban <ipid> \"<reason>\" \"<duration>\"");
+    if (argc < 3) {
+        sendServerMessage("Invalid syntax. Usage:\n/ban <ipid> <duration> <reason>");
         return;
     }
 
-    ban.reason = unquoted_args.at(0);
-    if (unquoted_args.length() > 1)
-        duration = unquoted_args.at(1);
-
     long long duration_seconds = 0;
-    if (duration == "perma")
+    if (argv[1] == "perma")
         duration_seconds = -2;
     else
-        duration_seconds = parseTime(duration);
+        duration_seconds = parseTime(argv[1]);
 
     if (duration_seconds == -1) {
         sendServerMessage("Invalid time format. Format example: 1h30m");
@@ -61,16 +47,17 @@ void AOClient::cmdBan(int argc, QStringList argv)
     }
 
     ban.duration = duration_seconds;
-
     ban.ipid = argv[0];
+    ban.reason = args_str;
     ban.time = QDateTime::currentDateTime().toSecsSinceEpoch();
     bool ban_logged = false;
     int kick_counter = 0;
 
-    if (argc > 2) {
-        for (int i = 2; i < argv.length(); i++) {
-            ban.reason += " " + argv[i];
-        }
+    if (server->auth_type == "advanced") {
+        ban.moderator = moderator_name;
+    }
+    else {
+        ban.moderator = "moderator";
     }
 
     for (AOClient* client : server->getClientsByIpid(ban.ipid)) {
@@ -81,7 +68,14 @@ void AOClient::cmdBan(int argc, QStringList argv)
             sendServerMessage("Banned user with ipid " + ban.ipid + " for reason: " + ban.reason);
             ban_logged = true;
         }
-        client->sendPacket("KB", {ban.reason + "\nID: " + QString::number(server->db_manager->getBanID(ban.ip)) + "\nUntil: " + QDateTime::fromSecsSinceEpoch(ban.time).addSecs(ban.duration).toString("dd.MM.yyyy, hh:mm")});
+        QString ban_duration;
+        if (!(ban.duration == -2)) {
+            ban_duration = QDateTime::fromSecsSinceEpoch(ban.time).addSecs(ban.duration).toString("MM/dd/yyyy, hh:mm");
+        }
+        else {
+            ban_duration = "The heat death of the universe.";
+        }
+        client->sendPacket("KB", {ban.reason + "\nID: " + QString::number(server->db_manager->getBanID(ban.ip)) + "\nUntil: " + ban_duration});
         client->socket->close();
         kick_counter++;
     }
@@ -185,6 +179,7 @@ void AOClient::cmdBans(int argc, QStringList argv)
         recent_bans << "Reason for ban: " + ban.reason;
         recent_bans << "Date of ban: " + QDateTime::fromSecsSinceEpoch(ban.time).toString("MM/dd/yyyy, hh:mm");
         recent_bans << "Ban lasts until: " + banned_until;
+        recent_bans << "Moderator: " + ban.moderator;
         recent_bans << "-----";
     }
     sendServerMessage(recent_bans.join("\n"));
@@ -369,12 +364,14 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
         if (ban.duration == -2)
             banned_until = "The heat death of the universe";
         else
-            banned_until = QDateTime::fromSecsSinceEpoch(ban.time).addSecs(ban.duration).toString("dd.MM.yyyy, hh:mm");
+            banned_until = QDateTime::fromSecsSinceEpoch(ban.time).addSecs(ban.duration).toString("MM/dd/yyyy, hh:mm");
+        ban_info << "Ban ID: " + QString::number(ban.id);
         ban_info << "Affected IPID: " + ban.ipid;
         ban_info << "Affected HDID: " + ban.hdid;
         ban_info << "Reason for ban: " + ban.reason;
-        ban_info << "Date of ban: " + QDateTime::fromSecsSinceEpoch(ban.time).toString("dd.MM.yyyy, hh:mm");
+        ban_info << "Date of ban: " + QDateTime::fromSecsSinceEpoch(ban.time).toString("MM/dd/yyyy, hh:mm");
         ban_info << "Ban lasts until: " + banned_until;
+        ban_info << "Moderator: " + ban.moderator;
         ban_info << "-----";
     }
     sendServerMessage(ban_info.join("\n"));


### PR DESCRIPTION
* Add a versioning system to the akashi DB, utilizing PRAGMA user_version. The DB will automatically update outdated databases.
* Adds a moderator column to the ban table, storing the name of the moderator that issued the ban.
* Changes the syntax of /bans to: `/ban <ipid> <duration> <reason>`. No more quotes!

Fixes:
* /bans and /baninfo will no longer incorrectly label values, and return them in the wrong order.
* Duration will no longer be stored in the reason field in the ban table.
* Clients that are permanently banned will now be shown the correct duration.