### PR TITLE
Allow banning clients not connected to the server

### DIFF
--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -696,7 +696,7 @@ class AreaData : public QObject {
      * * First, a `QStringList` that is the packet of the statement that was advanced to.
      * * Then, a `TestimonyProgress` value that describes how the advancement happened.
      */
-    std::pair<QStringList, AreaData::TestimonyProgress> jumpToStatement(int f_position);
+    QPair<QStringList, AreaData::TestimonyProgress> jumpToStatement(int f_position);
 
     /**
      * @brief Returns a copy of the judgelog in the area.

--- a/core/include/db_manager.h
+++ b/core/include/db_manager.h
@@ -64,7 +64,7 @@ public:
      * * First, a `bool` that is true if the query could return at least one such record.
      * * Then, a `QString` that is the reason for the ban.
      */
-    std::pair<bool, QString> isIPBanned(QString ipid);
+    QPair<bool, QString> isIPBanned(QString ipid);
 
     /**
      * @brief Checks if there is a record in the Bans table with the given hardware ID.
@@ -75,7 +75,7 @@ public:
      * * First, a `bool` that is true if the query could return at least one such record.
      * * Then, a `QString` that is the reason for the ban.
      */
-    std::pair<bool, QString> isHDIDBanned(QString hdid);
+    QPair<bool, QString> isHDIDBanned(QString hdid);
 
     /**
      * @brief Gets the ID number of a given ban.

--- a/core/include/db_manager.h
+++ b/core/include/db_manager.h
@@ -56,13 +56,15 @@ public:
     ~DBManager();
 
     /**
-     * @brief Checks if there is a record in the Bans table with the given IP address.
+     * @brief Checks if there is a record in the Bans table with the given IPID.
      *
-     * @param ip The IP address to check if it is banned.
+     * @param ipid The IPID to check if it is banned.
      *
-     * @return True if the query could return at least one such record.
+     * @return A pair of values:
+     * * First, a `bool` that is true if the query could return at least one such record.
+     * * Then, a `QString` that is the reason for the ban.
      */
-    bool isIPBanned(QHostAddress ip);
+    std::pair<bool, QString> isIPBanned(QString ipid);
 
     /**
      * @brief Checks if there is a record in the Bans table with the given hardware ID.

--- a/core/include/db_manager.h
+++ b/core/include/db_manager.h
@@ -71,39 +71,11 @@ public:
      *
      * @param hdid The hardware ID to check if it is banned.
      *
-     * @return True if the query could return at least one such record.
+     * @return A pair of values:
+     * * First, a `bool` that is true if the query could return at least one such record.
+     * * Then, a `QString` that is the reason for the ban.
      */
-    bool isHDIDBanned(QString hdid);
-
-    /**
-     * @brief Returns the reason the given IP address was banned with.
-     *
-     * @param ip The IP address whose ban reason needs to be returned.
-     *
-     * @return The ban reason if the IP address is actually banned,
-     * or `"Ban reason not found."` if the IP address is not actually banned.
-     */
-    QString getBanReason(QHostAddress ip);
-
-    /**
-     * @overload
-     */
-    QString getBanReason(QString hdid);
-
-    /**
-     * @brief Returns the reason the given IP address was banned with.
-     *
-     * @param ip The IP address whose ban duration to get.
-     *
-     * @return The ban duration if the IP address is actually banned,
-     * or `-1` if the IP address is not actually banned.
-     */
-    long long getBanDuration(QHostAddress ip);
-
-    /**
-     * @overload
-     */
-    long long getBanDuration(QString hdid);
+    std::pair<bool, QString> isHDIDBanned(QString hdid);
 
     /**
      * @brief Gets the ID number of a given ban.

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -403,7 +403,7 @@ void AreaData::removeStatement(int f_position)
     --m_statement;
 }
 
-std::pair<QStringList, AreaData::TestimonyProgress> AreaData::jumpToStatement(int f_position)
+QPair<QStringList, AreaData::TestimonyProgress> AreaData::jumpToStatement(int f_position)
 {
     m_statement = f_position;
 

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -82,8 +82,12 @@ void AOClient::cmdBan(int argc, QStringList argv)
 
     if (kick_counter > 1)
         sendServerMessage("Kicked " + QString::number(kick_counter) + " clients with matching ipids.");
-    if (!ban_logged)
-        sendServerMessage("User with ipid not found!");
+
+    // We're banning someone not connected.
+    if (!ban_logged) {
+        server->db_manager->addBan(ban);
+        sendServerMessage("Banned " + ban.ipid + " for reason: " + ban.reason);
+    }
 }
 
 void AOClient::cmdKick(int argc, QStringList argv)

--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -31,7 +31,7 @@ DBManager::DBManager() :
         updateDB(db_version);
 }
 
-std::pair<bool, QString> DBManager::isIPBanned(QString ipid)
+QPair<bool, QString> DBManager::isIPBanned(QString ipid)
 {
     QSqlQuery query;
     query.prepare("SELECT * FROM BANS WHERE IPID = ? ORDER BY TIME DESC");
@@ -51,7 +51,7 @@ std::pair<bool, QString> DBManager::isIPBanned(QString ipid)
     else return {false, nullptr};
 }
 
-std::pair<bool, QString> DBManager::isHDIDBanned(QString hdid)
+QPair<bool, QString> DBManager::isHDIDBanned(QString hdid)
 {
     QSqlQuery query;
     query.prepare("SELECT * FROM BANS WHERE HDID = ? ORDER BY TIME DESC");

--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -31,23 +31,24 @@ DBManager::DBManager() :
         updateDB(db_version);
 }
 
-bool DBManager::isIPBanned(QHostAddress ip)
+std::pair<bool, QString> DBManager::isIPBanned(QString ipid)
 {
     QSqlQuery query;
-    query.prepare("SELECT TIME FROM BANS WHERE IP = ? ORDER BY TIME DESC");
-    query.addBindValue(ip.toString());
+    query.prepare("SELECT * FROM BANS WHERE IPID = ? ORDER BY TIME DESC");
+    query.addBindValue(ipid);
     query.exec();
     if (query.first()) {
-        long long duration = getBanDuration(ip);
-        long long ban_time = query.value(0).toLongLong();
+        long long ban_time = query.value(4).toLongLong();
+        QString reason = query.value(5).toString();
+        long long duration = query.value(6).toLongLong();
         if (duration == -2)
-            return true;
+            return {true, reason};
         long long current_time = QDateTime::currentDateTime().toSecsSinceEpoch();
         if (ban_time + duration > current_time)
-            return true;
-        else return false;
+            return {true, reason};
+        else return {false, nullptr};
     }
-    else return false;
+    else return {false, nullptr};
 }
 
 bool DBManager::isHDIDBanned(QString hdid)

--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -51,81 +51,25 @@ std::pair<bool, QString> DBManager::isIPBanned(QString ipid)
     else return {false, nullptr};
 }
 
-bool DBManager::isHDIDBanned(QString hdid)
+std::pair<bool, QString> DBManager::isHDIDBanned(QString hdid)
 {
     QSqlQuery query;
-    query.prepare("SELECT TIME FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
+    query.prepare("SELECT * FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
     query.addBindValue(hdid);
     query.exec();
     if (query.first()) {
-        long long duration = getBanDuration(hdid);
-        long long ban_time = query.value(0).toLongLong();
+        long long ban_time = query.value(4).toLongLong();
+        QString reason = query.value(5).toString();
+        long long duration = query.value(6).toLongLong();
         if (duration == -2)
-            return true;
+            return {true, reason};
         long long current_time = QDateTime::currentDateTime().toSecsSinceEpoch();
         if (ban_time + duration > current_time)
-            return true;
-        else return false;
+            return {true, reason};
+        else return {false, nullptr};
     }
-    else return false;
+    else return {false, nullptr};
 }
-
-QString DBManager::getBanReason(QHostAddress ip)
-{
-    QSqlQuery query;
-    query.prepare("SELECT REASON FROM BANS WHERE IP = ? ORDER BY TIME DESC");
-    query.addBindValue(ip.toString());
-    query.exec();
-    if (query.first()) {
-        return query.value(0).toString();
-    }
-    else {
-        return "Ban reason not found.";
-    }
-}
-
-QString DBManager::getBanReason(QString hdid)
-{
-    QSqlQuery query;
-    query.prepare("SELECT REASON FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
-    query.addBindValue(hdid);
-    query.exec();
-    if (query.first()) {
-        return query.value(0).toString();
-    }
-    else {
-        return "Ban reason not found.";
-    }
-}
-
-long long DBManager::getBanDuration(QString hdid)
-{
-    QSqlQuery query;
-    query.prepare("SELECT DURATION FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
-    query.addBindValue(hdid);
-    query.exec();
-    if (query.first()) {
-        return query.value(0).toLongLong();
-    }
-    else {
-        return -1;
-    }
-}
-
-long long DBManager::getBanDuration(QHostAddress ip)
-{
-    QSqlQuery query;
-    query.prepare("SELECT DURATION FROM BANS WHERE IP = ? ORDER BY TIME DESC");
-    query.addBindValue(ip.toString());
-    query.exec();
-    if (query.first()) {
-        return query.value(0).toLongLong();
-    }
-    else {
-        return -1;
-    }
-}
-
 
 int DBManager::getBanID(QString hdid)
 {

--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -34,13 +34,13 @@ DBManager::DBManager() :
 QPair<bool, QString> DBManager::isIPBanned(QString ipid)
 {
     QSqlQuery query;
-    query.prepare("SELECT * FROM BANS WHERE IPID = ? ORDER BY TIME DESC");
+    query.prepare("SELECT TIME,REASON,DURATION FROM BANS WHERE IPID = ? ORDER BY TIME DESC");
     query.addBindValue(ipid);
     query.exec();
     if (query.first()) {
-        long long ban_time = query.value(4).toLongLong();
-        QString reason = query.value(5).toString();
-        long long duration = query.value(6).toLongLong();
+        long long ban_time = query.value(0).toLongLong();
+        QString reason = query.value(1).toString();
+        long long duration = query.value(2).toLongLong();
         if (duration == -2)
             return {true, reason};
         long long current_time = QDateTime::currentDateTime().toSecsSinceEpoch();
@@ -54,13 +54,13 @@ QPair<bool, QString> DBManager::isIPBanned(QString ipid)
 QPair<bool, QString> DBManager::isHDIDBanned(QString hdid)
 {
     QSqlQuery query;
-    query.prepare("SELECT * FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
+    query.prepare("SELECT TIME,REASON,DURATION FROM BANS WHERE HDID = ? ORDER BY TIME DESC");
     query.addBindValue(hdid);
     query.exec();
     if (query.first()) {
-        long long ban_time = query.value(4).toLongLong();
-        QString reason = query.value(5).toString();
-        long long duration = query.value(6).toLongLong();
+        long long ban_time = query.value(0).toLongLong();
+        QString reason = query.value(1).toString();
+        long long duration = query.value(2).toLongLong();
         if (duration == -2)
             return {true, reason};
         long long current_time = QDateTime::currentDateTime().toSecsSinceEpoch();

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -27,8 +27,9 @@ void AOClient::pktDefault(AreaData* area, int argc, QStringList argv, AOPacket p
 void AOClient::pktHardwareId(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
     hwid = argv[0];
-    if(server->db_manager->isHDIDBanned(hwid)) {
-        sendPacket("BD", {server->db_manager->getBanReason(hwid) + "\nBan ID: " + QString::number(server->db_manager->getBanID(hwid))});
+    auto ban = server->db_manager->isHDIDBanned(hwid);
+    if (ban.first) {
+        sendPacket("BD", {ban.second + "\nBan ID: " + QString::number(server->db_manager->getBanID(hwid))});
         socket->close();
         return;
     }
@@ -318,10 +319,8 @@ void AOClient::pktWebSocketIp(AreaData* area, int argc, QStringList argv, AOPack
     calculateIpid();
     if (remote_ip.isLoopback()) {
         auto ban = server->db_manager->isIPBanned(ipid);
-        bool is_banned = ban.first;
-        if(is_banned) {
-            QString reason = ban.second;
-            sendPacket("BD", {reason});
+        if (ban.first) {
+            sendPacket("BD", {ban.second});
             socket->close();
             return;
         }

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -316,18 +316,18 @@ void AOClient::pktWebSocketIp(AreaData* area, int argc, QStringList argv, AOPack
 {
     // Special packet to set remote IP from the webao proxy
     // Only valid if from a local ip
-    calculateIpid();
     if (remote_ip.isLoopback()) {
+#ifdef NET_DEBUG
+        qDebug() << "ws ip set to" << argv[0];
+#endif
+        remote_ip = QHostAddress(argv[0]);
+        calculateIpid();
         auto ban = server->db_manager->isIPBanned(ipid);
         if (ban.first) {
             sendPacket("BD", {ban.second});
             socket->close();
             return;
         }
-#ifdef NET_DEBUG
-        qDebug() << "ws ip set to" << argv[0];
-#endif
-        remote_ip = QHostAddress(argv[0]);
 
         int multiclient_count = 0;
         for (AOClient* joined_client : server->clients) {


### PR DESCRIPTION
Allows you to ban any IPID, regardless of whether it is connected to the server or not. To accomplish this, IPIDs are used for IP bans instead of remote IPs.

In addition, this PR cleans up both isIPBanned() and isHDIDBanned() by removing extraneous DB queries. It removes getBanDuration and getBanReason, and instead isIPBanned and isHDIDBanned() will retrieve this info in it's single query.

Closes #96 