### PR TITLE
Fix crash with /ban

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1937,7 +1937,7 @@ class AOClient : public QObject {
         {"login",              {ACLFlags.value("NONE"),         0, &AOClient::cmdLogin}},
         {"getareas",           {ACLFlags.value("NONE"),         0, &AOClient::cmdGetAreas}},
         {"getarea",            {ACLFlags.value("NONE"),         0, &AOClient::cmdGetArea}},
-        {"ban",                {ACLFlags.value("BAN"),          2, &AOClient::cmdBan}},
+        {"ban",                {ACLFlags.value("BAN"),          3, &AOClient::cmdBan}},
         {"kick",               {ACLFlags.value("KICK"),         2, &AOClient::cmdKick}},
         {"changeauth",         {ACLFlags.value("SUPER"),        0, &AOClient::cmdChangeAuth}},
         {"rootpass",           {ACLFlags.value("SUPER"),        1, &AOClient::cmdSetRootPass}},

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -30,11 +30,6 @@ void AOClient::cmdBan(int argc, QStringList argv)
 
     DBManager::BanInfo ban;
 
-    if (argc < 3) {
-        sendServerMessage("Invalid syntax. Usage:\n/ban <ipid> <duration> <reason>");
-        return;
-    }
-
     long long duration_seconds = 0;
     if (argv[1] == "perma")
         duration_seconds = -2;


### PR DESCRIPTION
Sets /ban to require 3 arguments instead of 2