### PR TITLE
Discord webhook refactor

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -28,7 +28,7 @@ max_dice=100
 
 [Discord]
 webhook_enabled=false
-webhook_url=Your webhook url here.
+webhook_url=
 webhook_sendfile=false
 webhook_content=
 

--- a/core/include/discord.h
+++ b/core/include/discord.h
@@ -20,6 +20,7 @@
 
 #include <QtNetwork>
 #include <QCoreApplication>
+#include "config_manager.h"
 
 /**
  * @brief A class for handling all Discord webhook requests.
@@ -36,7 +37,7 @@ public:
      * @param f_webhook_sendfile Whether or not to send a file containing area logs with the webhook POST request.
      * @param parent Qt-based parent, passed along to inherited constructor from QObject.
      */
-    Discord(const QUrl& f_webhook_url, const QString& f_webhook_content, const bool& f_webhook_sendfile, QObject* parent = nullptr);
+    Discord(QObject* parent = nullptr);
 
     /**
       * @brief Deconstructor for the Discord class.
@@ -100,16 +101,6 @@ private:
      * @brief The QNetworkRequest for webhooks.
      */
     QNetworkRequest m_request;
-
-    /**
-     * @brief The content to include in the webhook POST request.
-     */
-    const QString& m_webhook_content;
-
-    /**
-     * @brief Whether or not to send a file containing area logs with the webhook POST request.
-     */
-    const bool& m_webhook_sendfile;
 
 private slots:
     /**

--- a/core/include/discord.h
+++ b/core/include/discord.h
@@ -20,48 +20,104 @@
 
 #include <QtNetwork>
 #include <QCoreApplication>
-#include "server.h"
 
-class Server;
-
+/**
+ * @brief A class for handling all Discord webhook requests.
+ */
 class Discord : public QObject {
     Q_OBJECT
 
 public:
     /**
-     * @brief Creates an instance of the Discord class.
+     * @brief Constructor for the Discord object
      *
-     * @param p_server A pointer to the Server instance Discord is constructed by.
+     * @param f_webhook_url The URL to send webhook POST requests to.
+     * @param f_webhook_content The content to include in the webhook POST request.
+     * @param f_webhook_sendfile Whether or not to send a file containing area logs with the webhook POST request.
      * @param parent Qt-based parent, passed along to inherited constructor from QObject.
      */
-    Discord(Server* p_server, QObject* parent = nullptr)
-        : QObject(parent), server(p_server) {
-    };
+    Discord(const QUrl& f_webhook_url, const QString& f_webhook_content, const bool& f_webhook_sendfile, QObject* parent = nullptr);
+
+    /**
+      * @brief Deconstructor for the Discord class.
+      *
+      * @details Marks the nam to be deleted later.
+      */
+    ~Discord();
+
+    /**
+     * @brief Sends a webhook POST request with the given JSON document.
+     *
+     * @param f_json The JSON document to send.
+     */
+    void postJsonWebhook(const QJsonDocument& f_json);
+
+    /**
+     * @brief Sends a webhook POST request with the given QHttpMultiPart.
+     *
+     * @param f_multipart The QHttpMultiPart to send.
+     */
+    void postMultipartWebhook(QHttpMultiPart& f_multipart);
+
+    /**
+     * @brief Constructs a new JSON document for modcalls.
+     *
+     * @param f_name The name of the modcall sender.
+     * @param f_area The name of the area the modcall was sent from.
+     * @param f_reason The reason for the modcall.
+     *
+     * @return A JSON document for the modcall.
+     */
+    QJsonDocument constructModcallJson(const QString& f_name, const QString& f_area, const QString& f_reason) const;
+
+    /**
+     * @brief Constructs a new QHttpMultiPart document for log files.
+     *
+     * @param f_buffer The area's log buffer.
+     *
+     * @return A QHttpMultiPart containing the log file.
+     */
+    QHttpMultiPart* constructLogMultipart(const QQueue<QString>& f_buffer) const;
 
 public slots:
-
     /**
-     * @brief Sends a modcall to a discord webhook.
+     * @brief Handles a modcall webhook request.
      *
-     * @param name The character or OOC name of the client who sent the modcall.
-     * @param area The area name of the area the modcall was sent from.
-     * @param reason The reason the client specified for the modcall.
-     * @param current_area The index of the area the modcall is made.
+     * @param f_name The name of the modcall sender.
+     * @param f_area The name of the area the modcall was sent from.
+     * @param f_reason The reason for the modcall.
+     * @param f_buffer The area's log buffer.
      */
-    void postModcallWebhook(QString name, QString reason, int current_area);
-
-    /**
-     * @brief Sends the reply to the POST request sent by Discord::postModcallWebhook.
-     */
-    void onFinish(QNetworkReply *reply);
+    void onModcallWebhookRequested(const QString& f_name, const QString& f_area, const QString& f_reason, const QQueue<QString>& f_buffer);
 
 private:
+    /**
+     * @brief The QNetworkAccessManager for webhooks.
+     */
+    QNetworkAccessManager* m_nam;
 
     /**
-     * @brief A pointer to the Server.
+     * @brief The QNetworkRequest for webhooks.
      */
-    Server* server;
+    QNetworkRequest m_request;
 
+    /**
+     * @brief The content to include in the webhook POST request.
+     */
+    const QString& m_webhook_content;
+
+    /**
+     * @brief Whether or not to send a file containing area logs with the webhook POST request.
+     */
+    const bool& m_webhook_sendfile;
+
+private slots:
+    /**
+     * @brief Handles a network reply from a webhook POST request.
+     *
+     * @param f_reply Pointer to the QNetworkReply created by the webhook POST request.
+     */
+    void onReplyFinished(QNetworkReply* f_reply);
 };
 
 #endif // DISCORD_H

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -38,7 +38,6 @@
 class AOClient;
 class DBManager;
 class AreaData;
-class Discord;
 
 /**
  * @brief The class that represents the actual server as it is.
@@ -242,7 +241,7 @@ class Server : public QObject {
     /**
      * @brief Requires an https Webhook link, including both ID and Token in the link.
      */
-    QString webhook_url;
+    QUrl webhook_url;
 
     /**
      * @brief If the modcall buffer is sent as a file.
@@ -392,11 +391,12 @@ class Server : public QObject {
     /**
      * @brief Sends a modcall webhook request, emitted by AOClient::pktModcall.
      *
-     * @param name The character or OOC name of the client who sent the modcall.
-     * @param reason The reason the client specified for the modcall.
-     * @param current_area Integer ID of the area the modcall is made.
+     * @param f_name The character or OOC name of the client who sent the modcall.
+     * @param f_area The name of the area the modcall was sent from.
+     * @param f_reason The reason the client specified for the modcall.
+     * @param f_buffer The area's log buffer.
      */
-    void webhookRequest(QString name, QString reason, int current_area);
+    void modcallWebhookRequest(const QString& f_name, const QString& f_area, const QString& f_reason, const QQueue<QString>& f_buffer);
 
   private:
     /**
@@ -412,6 +412,11 @@ class Server : public QObject {
     QTcpServer* server;
 
     /**
+     * @brief Handles Discord webhooks.
+     */
+    Discord* discord;
+
+    /**
      * @brief The port through which the server will accept TCP connections.
      */
     int port;
@@ -420,11 +425,6 @@ class Server : public QObject {
      * @brief The port through which the server will accept WebSocket connections.
      */
     int ws_port;
-
-    /**
-     * @brief Handles discord webhooks.
-     */
-    Discord* discord;
 };
 
 #endif // SERVER_H

--- a/core/src/discord.cpp
+++ b/core/src/discord.cpp
@@ -17,17 +17,15 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include "include/discord.h"
 
-Discord::Discord(const QUrl &f_webhook_url, const QString &f_webhook_content, const bool &f_webhook_sendfile, QObject* parent) :
-    QObject(parent),
-    m_webhook_content(f_webhook_content),
-    m_webhook_sendfile(f_webhook_sendfile)
+Discord::Discord(QObject* parent) :
+    QObject(parent)
 {
-    if (!QUrl(f_webhook_url).isValid())
+    if (!QUrl(ConfigManager::discordWebhookUrl()).isValid())
         qWarning("Invalid webhook URL!");
     m_nam = new QNetworkAccessManager();
     connect(m_nam, &QNetworkAccessManager::finished,
             this, &Discord::onReplyFinished);
-    m_request.setUrl(f_webhook_url);
+    m_request.setUrl(QUrl(ConfigManager::discordWebhookUrl()));
 }
 
 void Discord::onModcallWebhookRequested(const QString &f_name, const QString &f_area, const QString &f_reason, const QQueue<QString> &f_buffer)
@@ -35,7 +33,7 @@ void Discord::onModcallWebhookRequested(const QString &f_name, const QString &f_
     QJsonDocument l_json = constructModcallJson(f_name, f_area, f_reason);
     postJsonWebhook(l_json);
 
-    if (m_webhook_sendfile) {
+    if (ConfigManager::discordWebhookSendFile()) {
         QHttpMultiPart *l_multipart = constructLogMultipart(f_buffer);
         postMultipartWebhook(*l_multipart);
     }
@@ -52,8 +50,8 @@ QJsonDocument Discord::constructModcallJson(const QString &f_name, const QString
     };
     l_array.append(l_object);
     l_json["embeds"] = l_array;
-    if (!m_webhook_content.isEmpty())
-        l_json["content"] = m_webhook_content;
+    if (!ConfigManager::discordWebhookContent().isEmpty())
+        l_json["content"] = ConfigManager::discordWebhookContent();
 
     return QJsonDocument(l_json);
 }

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -353,7 +353,7 @@ void AOClient::pktModCall(AreaData* area, int argc, QStringList argv, AOPacket p
         if (ooc_name.isEmpty())
             name = current_char;
 
-        server->webhookRequest(name, packet.contents[0], current_area);
+        emit server->modcallWebhookRequest(name, server->areas[current_area]->name(), packet.contents[0], area->buffer());
     }
     
     area->flushLogs();

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -52,7 +52,7 @@ void Server::start()
     }
     
     if (ConfigManager::discordWebhookEnabled()) {
-        discord = new Discord(webhook_url, webhook_content, webhook_sendfile, this);
+        discord = new Discord(this);
         connect(this, &Server::modcallWebhookRequest,
                 discord, &Discord::onModcallWebhookRequested);
     }


### PR DESCRIPTION
Completely refactors the Discord class, breaking it up into separate functions and slots, removing circular dependencies, and replacing most pointers with const references.

This also prepares the Discord class for additional webhook requests, instead of exclusively modcalls.