### PR TITLE
Rewrite ConfigManager and introduce new types for auth and logging.

### DIFF
--- a/akashi/main.cpp
+++ b/akashi/main.cpp
@@ -39,12 +39,10 @@ int main(int argc, char* argv[])
     QCoreApplication::setApplicationVersion("banana");
     std::atexit(cleanup);
 
-    ConfigManager config_manager;
-    if (config_manager.initConfig()) {
+    if (ConfigManager::verifyServerConfig()) {
         // Config is sound, so proceed with starting the server
         // Validate some of the config before passing it on
-        ConfigManager::server_settings settings;
-        bool config_valid = config_manager.loadServerSettings(&settings);
+        bool config_valid = ConfigManager::loadConfigSettings();
         if (!config_valid) {
             qCritical() << "config.ini is invalid!";
             qCritical() << "Exiting server due to configuration issue.";
@@ -53,15 +51,15 @@ int main(int argc, char* argv[])
         }
 
         else {
-            if (settings.advertise_server) {
+            if (ConfigManager::advertiseServer()) {
                 advertiser =
-                    new Advertiser(settings.ms_ip, settings.ms_port,
-                                   settings.ws_port, settings.port,
-                                   settings.name, settings.description);
+                    new Advertiser(ConfigManager::masterServerIP(), ConfigManager::masterServerPort(),
+                                   ConfigManager::webaoPort(), ConfigManager::serverPort(),
+                                   ConfigManager::serverName(), ConfigManager::serverDescription());
                 advertiser->contactMasterServer();
             }
 
-            server = new Server(settings.port, settings.ws_port);
+            server = new Server(ConfigManager::serverPort(), ConfigManager::webaoPort());
 
             if (advertiser != nullptr) {
                 QObject::connect(server, &Server::reloadRequest, advertiser, &Advertiser::reloadRequested);

--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -1,42 +1,104 @@
-[Info]
-version=1
-
 [Options]
+; Whether or not the server should appear on the master server.
 advertise=true
+
+; The maximum number of players that can join the server at once.
 max_players=100
+
+; The IP address of the master server. Unless something happens to the default one, you shouldn't change this.
 ms_ip=master.aceattorneyonline.com
+
+; The port of the master server. Unless something happens to the default one, you shouldn't change this.
 ms_port=27016
+
+; The TCP port to listen for incoming connections on.
 port=27016
+
+; The server description that will appear on the master server.
 server_description=This is a placeholder server description. Tell the world of AO who you are here!
+
+; The server's name. This appears both on the master server, and in messages sent to users by the server.
 server_name=An Unnamed Server
+
+; The server's Message of the Day. This will be sent in OOC to joining users.
 motd=MOTD is not set.
+
+; Whether the server should accept WebAO connections or not.
 webao_enable=true
+
+; The TCP port to listen for WebAO connections on. This must be different than the server port.
 webao_port=27017
+
+; The authorization level of the server. You shouldn't touch this, use /changeauth on the server instead.
 auth=simple
+
+; The moderator password used with simple authorization. Change this to something unique and secure.
 modpass=changeme
+
+; The amount of logged messages an area should store. Once this limit is reached, older messages will be overrwritten. 
+; This is only used for modcall logging, or if the webhook_sendfile is enabled.
 logbuffer=500
+
+; The server logging type. Valid values here are "modcall" and "full". 
+; Modcall logging will only save an area log file if a modcall is sent. 
+; Full logging will log every event in every area, and will output to a new file every day.
 logging=modcall
+
+; The maximum number of statements that can be recorded in the testimony recorder.
 maximum_statements=10
+
+; The maximum number of connections that will be accepted from the same IP address.
+; Multiclienting is generally used for casing/RPing, so the default value is fine in most cases.
 multiclient_limit=15
+
+; The maximum number of characters that an IC/OOC message can contain.
 maximum_characters=256
+
+; The minimum time between IC messages, in miliseconds. The default value is fine for most cases.
 message_floodguard=250
-asset_url=Your WebAO asset url here.
+
+; The URL of the server's remote repository, sent to the client during their initial handshake. Used by WebAO users for custom content.
+asset_url=
 
 [Dice]
+; The maximum number of sides dice can be rolled with.
 max_value=100
+
+; The maximum number of dice that can be rolled at once.
 max_dice=100
 
 [Discord]
+; Whether the discord webhook is enabled or not.
+; The server will send messages to this webhook whenever a modcall is sent.
 webhook_enabled=false
-webhook_url=Your webhook url here.
+
+; The URL of the discord webhook to send messages to. Must contain the webhook ID and token.
+webhook_url=
+
+; Whether to attach a file containing the area log when a modcall message is sent to the webhook.
 webhook_sendfile=false
+
+; Additional text to send with the webhook message. Usually for adding tags for roles, like @Administrator
 webhook_content=
 
 [Password]
+; Whether or not to enforce password requirements. Only applicable under advanced authorization.
 password_requirements = true
+
+; The minimum length passwords must be.
 pass_min_length = 8
+
+; The maximum length passwords can be. Set to 0 for unlimited length passwords.
 pass_max_length = 0
+
+; Whether passwords must contain both uppercase and lowercase letters.
 pass_required_mix_case = true
+
+; Whether passwords must contain at least one number.
 pass_required_numbers = true
+
+; Whether passwords must contain at least one special character.
 pass_required_special = true
+
+; Whether passwords can contain the username inside them.
 pass_can_contain_username = false

--- a/core/core.pro
+++ b/core/core.pro
@@ -52,6 +52,7 @@ HEADERS += include/advertiser.h \
     include/aopacket.h \
     include/area_data.h \
     include/config_manager.h \
+    include/data_types.h \
     include/db_manager.h \
     include/discord.h \
     include/logger.h \

--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -20,6 +20,7 @@
 
 #include "logger.h"
 #include "aopacket.h"
+#include "config_manager.h"
 
 #include <QMap>
 #include <QString>

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -20,85 +20,398 @@
 
 #define CONFIG_VERSION 1
 
+#include "data_types.h"
+
 #include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QSettings>
+#include <QUrl>
+#include <QMetaEnum>
 
 /**
  * @brief The config file handler class.
  */
 class ConfigManager {
+
   public:
     /**
-     * @brief An empty constructor for ConfigManager.
+     * @brief Verifies the server configuration, confirming all required files/directories exist and are valid.
+     *
+     * @return True if the server configuration was verified, false otherwise.
      */
-    ConfigManager() {};
+    static bool verifyServerConfig();
 
     /**
-     * @brief Performs some preliminary checks for the various configuration files used by the server.
+     * @brief Begins loading server settings from config.ini.
      *
-     * @return True if the config file exists, is up-to-date, and valid, false otherwise.
+     * @return True if the settings were successfully loaded, false otherwise.
      */
-    bool initConfig();
+    static bool loadConfigSettings();
 
     /**
-     * @brief Updates the config file's version to the one used by the server currently.
+     * @brief Reloads server settings from config.ini that can be reloaded. This is also called by `loadConfigSettings` to finish setting loading.
      *
-     * @details The function can return false if the server's expected config version is 0
-     * (doesn't actually exist), or negative (nonsense).
-     * If the current config file lags more than one version behind the expected, all intermediate
-     * updates are also performed on the config file.
+     * @return True if the server settings were successfully reloaded, false otherwise.
      *
-     * @param current_version The current configuration version expected by the server.
-     *
-     * @return True if a version update took place, false otherwise.
+     * @see loadConfigSettings
      */
-    bool updateConfig(int current_version);
+    static bool reloadConfigSettings();
 
     /**
-     * @brief The collection of server-specific settings.
+     * @brief Returns true if the server should advertise to the master server.
+     *
+     * @return See short description.
+     */
+    static bool advertiseServer();
+
+    /**
+     * @brief Returns the maximum number of players the server will allow.
+     *
+     * @return See short description.
+     */
+    static int maxPlayers();
+
+    /**
+     * @brief Returns the IP of the master server to advertise to.
+     *
+     * @return See short description.
+     */
+    static QString masterServerIP();
+
+    /**
+     * @brief Returns the port of the master server to advertise to.
+     *
+     * @return See short description.
+     */
+    static int masterServerPort();
+
+    /**
+     * @brief Returns the port to listen for connections on.
+     *
+     * @return See short description.
+     */
+    static int serverPort();
+
+    /**
+     * @brief Returns the server description.
+     *
+     * @return See short description.
+     */
+    static QString serverDescription();
+
+    /**
+     * @brief Returns the server name.
+     *
+     * @return See short description.
+     */
+    static QString serverName();
+
+    /**
+     * @brief Returns the server's Message of the Day.
+     *
+     * @return See short description.
+     */
+    static QString motd();
+
+    /**
+     * @brief Returns true if the server should accept webAO connections.
+     *
+     * @return See short description.
+     */
+    static bool webaoEnabled();
+
+    /**
+     * @brief Returns the port to listen for webAO connections on.
+     *
+     * @return See short description.
+     */
+    static int webaoPort();
+
+    /**
+     * @brief Returns the server's authorization type.
+     *
+     * @return See short description.
+     */
+    static DataTypes::AuthType authType();
+
+    /**
+     * @brief Returns the server's moderator password.
+     *
+     * @return See short description.
+     */
+    static QString modpass();
+
+    /**
+     * @brief Returns the server's log buffer length.
+     *
+     * @return See short description.
+     */
+    static int logBuffer();
+
+    /**
+     * @brief Returns the server's logging type.
+     *
+     * @return See short description.
+     */
+    static DataTypes::LogType loggingType();
+
+    /**
+     * @brief Returns true if the server should advertise to the master server.
+     *
+     * @return See short description.
+     */
+    static int maxStatements();
+
+    /**
+     * @brief Returns the maximum number of permitted connections from the same IP.
+     *
+     * @return See short description.
+     */
+    static int multiClientLimit();
+
+    /**
+     * @brief Returns the maximum number of characters a message can contain.
+     *
+     * @return See short description.
+     */
+    static int maxCharacters();
+
+    /**
+     * @brief Returns the duration of the message floodguard.
+     *
+     * @return See short description.
+     */
+    static int messageFloodguard();
+
+    /**
+     * @brief Returns the URL where the server should retrieve remote assets from.
+     *
+     * @return See short description.
+     */
+    static QUrl assetUrl();
+
+    /**
+     * @brief Returns the maximum number of sides dice can have.
+     *
+     * @return See short description.
+     */
+    static int diceMaxValue();
+
+    /**
+     * @brief Returns the maximum number of dice that can be rolled at once.
+     *
+     * @return See short description.
+     */
+    static int diceMaxDice();
+
+    /**
+     * @brief Returns true if the discord webhook is enabled.
+     *
+     * @return See short description.
+     */
+    static bool discordWebhookEnabled();
+
+    /**
+     * @brief Returns the discord webhook URL.
+     *
+     * @return See short description.
+     */
+    static QString discordWebhookUrl();
+
+    /**
+     * @brief Returns the discord webhook content.
+     *
+     * @return See short description.
+     */
+    static QString discordWebhookContent();
+
+    /**
+     * @brief Returns true if the discord webhook should send log files.
+     *
+     * @return See short description.
+     */
+    static bool discordWebhookSendFile();
+
+    /**
+     * @brief Returns true if password requirements should be enforced.
+     *
+     * @return See short description.
+     */
+    static bool passwordRequirements();
+
+    /**
+     * @brief Returns the minimum length passwords must be.
+     *
+     * @return See short description.
+     */
+    static int passwordMinLength();
+
+    /**
+     * @brief Returns the maximum length passwords can be, or `0` for unlimited length.
+     *
+     * @return See short description.
+     */
+    static int passwordMaxLength();
+
+    /**
+     * @brief Returns true if passwords must be mixed case.
+     *
+     * @return See short description.
+     */
+    static bool passwordRequireMixCase();
+
+    /**
+     * @brief Returns true is passwords must contain one or more numbers.
+     *
+     * @return See short description.
+     */
+    static bool passwordRequireNumbers();
+
+    /**
+     * @brief Returns true if passwords must contain one or more special characters..
+     *
+     * @return See short description.
+     */
+    static bool passwordRequireSpecialCharacters();
+
+    /**
+     * @brief Returns true if passwords can contain the username.
+     *
+     * @return See short description.
+     */
+    static bool passwordCanContainUsername();
+
+    /**
+     * @brief Returns the duration before a client is considered AFK.
+     *
+     * @return See short description.
+     */
+    static int afkTimeout();
+
+    /**
+     * @brief Returns a list of magic 8 ball answers.
+     *
+     * @return See short description.
+     */
+    static QStringList magic8BallAnswers();
+
+    /**
+     * @brief Returns a list of praises.
+     *
+     * @return See short description.
+     */
+    static QStringList praiseList();
+
+    /**
+     * @brief Returns a list of reprimands.
+     *
+     * @return See short description.
+     */
+    static QStringList reprimandsList();
+
+    /**
+     * @brief Returns the server gimp list.
+     *
+     * @return See short description.
+     */
+    static QStringList gimpList();
+
+    /**
+     * @brief Sets the server's authorization type.
+     *
+     * @param f_auth The auth type to set.
+     */
+    static void setAuthType(const DataTypes::AuthType f_auth);
+
+    /**
+     * @brief Sets the server's Message of the Day.
+     *
+     * @param f_motd The MOTD to set.
+     */
+    static void setMotd(const QString f_motd);
+
+private:
+    /**
+     * @brief Checks if a file exists and is valid.
+     *
+     * @param file The file to check.
+     *
+     * @return True if the file exists and is valid, false otherwise.
+     */
+    static bool fileExists(const QFileInfo& file);
+
+    /**
+     * @brief Checks if a directory exists and is valid.
+     *
+     * @param file The directory to check.
+     *
+     * @return True if the directory exists and is valid, false otherwise.
+     */
+    static bool dirExists(const QFileInfo& dir);
+
+    /**
+     * @brief A struct containing the server settings.
      */
     struct server_settings {
-        QString ms_ip; //!< The IP address of the master server to establish connection to.
-        int port; //!< The TCP port the server will accept client connections through.
-        int ws_port; //!< The WebSocket port the server will accept client connections through.
-        int ms_port; //!< The port of the master server to establish connection to.
-        QString name; //!< The name of the server as advertised on the server browser.
-        QString description; //!< The description of the server as advertised on the server browser.
-        bool advertise_server; //!< The server will only be announced to the master server (and thus appear on the master server list) if this is true.
+        // Options
+        bool advertise; //!< Whether the server should advertise to the master server.
+        int max_players; //!< Max number of players that can connect at once.
+        QString ms_ip; //!< IP of the master server.
+        int ms_port; //!< Port of the master server.
+        int port; //!< Server port.
+        QString server_description; //!< Server description.
+        QString server_name; //!< Server name.
+        QString motd; //!< Server Message of the Day.
+        bool webao_enable; //!< Whether the server should accept WebAO connections.
+        int webao_port; //!< Websocket port.
+        DataTypes::AuthType auth; //!< Server authorization type.
+        QString modpass; //!< Server moderator password.
+        int logbuffer; //!< Logbuffer length.
+        DataTypes::LogType logging; //!< Server logging type.
+        int maximum_statements; //!< Max testimony recorder statements.
+        int multiclient_limit; //!< Max number of multiclient connections.
+        int maximum_characters; //!< Max characters in a message.
+        int message_floodguard; //!< Message floodguard length.
+        QUrl asset_url; //!< Server asset URL.
+        int afk_timeout; //!< Server AFK timeout length.
+        // Dice
+        int max_value; //!< Max dice sides.
+        int max_dice; //!< Max amount of dice.
+        // Discord
+        bool webhook_enabled; //!< Whether the Discord webhook is enabled.
+        QString webhook_url; //!< URL of the Discord webhook.
+        QString webhook_content; //!< The content to send to the Discord webhook.
+        bool webhook_sendfile; //!< Whether to send log files to the Discord webhook.
+        // Password
+        bool password_requirements; //!< Whether to enforce password requirements.
+        int pass_min_length; //!< Minimum length of passwords.
+        int pass_max_length; //!< Maximum length of passwords.
+        bool pass_required_mix_case; //!< Whether passwords require mixed case.
+        bool pass_required_numbers; //!< Whether passwords require numbers.
+        bool pass_required_special; //!< Whether passwords require special characters.
+        bool pass_can_contain_username; //!< Whether passwords can contain the username.
+        // config/text/
+        QStringList magic_8ball_answers; //!< List of 8ball answers, from 8ball.txt
+        QStringList praise_list; //!< List of praises, from praise.txt
+        QStringList reprimands_list; //!< List of reprimands, from reprimands.txt
+        QStringList gimp_list; //!< List of gimp phrases, from gimp.txt
     };
 
     /**
-     * @brief Loads the server settings into the given struct from the config file.
-     *
-     * @param[out] settings Pointer to a server_settings file to be filled with data.
-     *
-     * @return False if any of the ports (the master server connection port,
-     * the TCP port used by clients, or the WebSocket port used by WebAO) failed
-     * to be read in from the settings correctly, true otherwise.
-     *
-     * @pre initConfig() must have been run beforehand to check for the config file's existence.
+     * @brief Stores all server configuration values.
      */
-    bool loadServerSettings(server_settings* settings);
-
-  private:
-    /**
-     * @brief Convenience function to check if the object exists, and is a file.
-     *
-     * @param file The object to check.
-     *
-     * @return See brief description.
-     */
-    bool fileExists(QFileInfo *file);
+    static server_settings* m_settings;
 
     /**
-     * @brief Verifies the existence of the command configuration files found in config/text/.
+     * @brief Returns a stringlist with the contents of a .txt file from config/text/.
      *
-     * @return True if the config files exist, and are files. False otherwise.
+     * @param Name of the file to load.
      */
-    bool verifyCommandConfig();
+    static QStringList loadConfigFile(const QString filename);
 };
+
+
 
 #endif // CONFIG_MANAGER_H

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -44,22 +44,6 @@ class ConfigManager {
     static bool verifyServerConfig();
 
     /**
-     * @brief Begins loading server settings from config.ini.
-     *
-     * @return True if the settings were successfully loaded, false otherwise.
-     */
-    static bool loadConfigSettings();
-
-    /**
-     * @brief Reloads server settings from config.ini that can be reloaded. This is also called by `loadConfigSettings` to finish setting loading.
-     *
-     * @return True if the server settings were successfully reloaded, false otherwise.
-     *
-     * @see loadConfigSettings
-     */
-    static bool reloadConfigSettings();
-
-    /**
      * @brief Returns true if the server should advertise to the master server.
      *
      * @return See short description.
@@ -332,6 +316,11 @@ class ConfigManager {
      */
     static void setMotd(const QString f_motd);
 
+    /**
+     * @brief Reload the server configuration.
+     */
+    static void reloadSettings();
+
 private:
     /**
      * @brief Checks if a file exists and is valid.
@@ -352,57 +341,24 @@ private:
     static bool dirExists(const QFileInfo& dir);
 
     /**
-     * @brief A struct containing the server settings.
+     * @brief A struct for storing QStringLists loaded from command configuration files.
      */
-    struct server_settings {
-        // Options
-        bool advertise; //!< Whether the server should advertise to the master server.
-        int max_players; //!< Max number of players that can connect at once.
-        QString ms_ip; //!< IP of the master server.
-        int ms_port; //!< Port of the master server.
-        int port; //!< Server port.
-        QString server_description; //!< Server description.
-        QString server_name; //!< Server name.
-        QString motd; //!< Server Message of the Day.
-        bool webao_enable; //!< Whether the server should accept WebAO connections.
-        int webao_port; //!< Websocket port.
-        DataTypes::AuthType auth; //!< Server authorization type.
-        QString modpass; //!< Server moderator password.
-        int logbuffer; //!< Logbuffer length.
-        DataTypes::LogType logging; //!< Server logging type.
-        int maximum_statements; //!< Max testimony recorder statements.
-        int multiclient_limit; //!< Max number of multiclient connections.
-        int maximum_characters; //!< Max characters in a message.
-        int message_floodguard; //!< Message floodguard length.
-        QUrl asset_url; //!< Server asset URL.
-        int afk_timeout; //!< Server AFK timeout length.
-        // Dice
-        int max_value; //!< Max dice sides.
-        int max_dice; //!< Max amount of dice.
-        // Discord
-        bool webhook_enabled; //!< Whether the Discord webhook is enabled.
-        QString webhook_url; //!< URL of the Discord webhook.
-        QString webhook_content; //!< The content to send to the Discord webhook.
-        bool webhook_sendfile; //!< Whether to send log files to the Discord webhook.
-        // Password
-        bool password_requirements; //!< Whether to enforce password requirements.
-        int pass_min_length; //!< Minimum length of passwords.
-        int pass_max_length; //!< Maximum length of passwords.
-        bool pass_required_mix_case; //!< Whether passwords require mixed case.
-        bool pass_required_numbers; //!< Whether passwords require numbers.
-        bool pass_required_special; //!< Whether passwords require special characters.
-        bool pass_can_contain_username; //!< Whether passwords can contain the username.
-        // config/text/
-        QStringList magic_8ball_answers; //!< List of 8ball answers, from 8ball.txt
-        QStringList praise_list; //!< List of praises, from praise.txt
-        QStringList reprimands_list; //!< List of reprimands, from reprimands.txt
-        QStringList gimp_list; //!< List of gimp phrases, from gimp.txt
+    struct CommandSettings {
+        QStringList magic_8ball; //!< Contains answers for /8ball, found in config/text/8ball.txt
+        QStringList praises; //!< Contains command praises, found in config/text/praises.txt
+        QStringList reprimands; //!< Contains command reprimands, found in config/text/reprimands.txt
+        QStringList gimps; //!< Contains phrases for /gimp, found in config/text/gimp.txt
     };
+
+    /**
+     * @brief Contains the settings required for various commands.
+     */
+    static CommandSettings* m_commands;
 
     /**
      * @brief Stores all server configuration values.
      */
-    static server_settings* m_settings;
+    static QSettings* m_settings;
 
     /**
      * @brief Returns a stringlist with the contents of a .txt file from config/text/.

--- a/core/include/data_types.h
+++ b/core/include/data_types.h
@@ -1,0 +1,59 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//    akashi - a server for Attorney Online 2                                       //
+//    Copyright (C) 2020  scatterflower                                             //
+//                                                                                  //
+//    This program is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU Affero General Public License as                //
+//    published by the Free Software Foundation, either version 3 of the            //
+//    License, or (at your option) any later version.                               //
+//                                                                                  //
+//    This program is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of                //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                 //
+//    GNU Affero General Public License for more details.                           //
+//                                                                                  //
+//    You should have received a copy of the GNU Affero General Public License      //
+//    along with this program.  If not, see <https://www.gnu.org/licenses/>.        //
+//////////////////////////////////////////////////////////////////////////////////////
+#ifndef DATA_TYPES_H
+#define DATA_TYPES_H
+
+#include <QDebug>
+/**
+ * @brief A class for handling several custom data types.
+ */
+class DataTypes
+{
+    Q_GADGET
+
+public:
+    /**
+     * @brief Custom type for authorization types.
+     */
+    enum class AuthType {
+            SIMPLE,
+            ADVANCED
+        };
+    Q_ENUM(AuthType);
+
+    /**
+     * @brief Custom type for logging types.
+     */
+    enum class LogType {
+        MODCALL,
+        FULL
+    };
+    Q_ENUM(LogType)
+};
+
+template<typename T>
+T toDataType(const QString& f_string){
+    return QVariant(f_string).value<T>();
+}
+
+template<typename T>
+QString fromDataType(const T& f_t){
+    return QVariant::fromValue(f_t).toString();
+}
+
+#endif // DATA_TYPES_H

--- a/core/include/logger.h
+++ b/core/include/logger.h
@@ -23,6 +23,7 @@
 #include <QString>
 #include <QQueue>
 #include <QDateTime>
+#include "data_types.h"
 
 /**
  * @brief A class associated with an AreaData class to log various events happening inside the latter.
@@ -35,7 +36,7 @@ public:
      *
      * @param f_max_length The maximum amount of entries the Logger can store at once.
      */
-    Logger(QString f_area_name, int f_max_length, const QString& f_logType_r) :
+    Logger(QString f_area_name, int f_max_length, const DataTypes::LogType& f_logType_r) :
         m_areaName(f_area_name), m_maxLength(f_max_length), m_logType(f_logType_r) {};
 
     /**
@@ -132,7 +133,7 @@ private:
      * @details This largely influences the resulting log file's name, and in case of a `"full"` setup,
      * the in-memory buffer is auto-dumped to said file if full.
      */
-    QString m_logType;
+    DataTypes::LogType m_logType;
 };
 
 #endif // LOGGER_H

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -24,6 +24,7 @@
 #include "include/ws_proxy.h"
 #include "include/db_manager.h"
 #include "include/discord.h"
+#include "include/config_manager.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -184,124 +185,12 @@ class Server : public QObject {
     DBManager* db_manager;
 
     /**
-     * @brief The max amount of players on the server.
-     */
-    QString max_players;
-    /**
-     * @brief The user-facing server name.
-     */
-    QString server_name;
-
-    /**
-     * @brief The server description.
-     */
-    QString server_desc;
-
-    /**
-     * @brief The Message Of The Day of the server, shown upon entry to the server and on request.
-     */
-    QString MOTD;
-
-   /**
-    * @brief The Maximum amounts of IC-Messages an area is allowed to store.
-    */
-    int maximum_statements;
-
-    /**
-     * @brief The authorization type of the server.
-     *
-     * @details In simple mode, the modpass stored in config.ini is used for moderator logins. In advanced mode, logins found in the database are used.
-     */
-    QString auth_type;
-
-    /**
-     * @brief The modpass for moderator login with simple auth_type.
-     */
-    QString modpass;
-
-    /**
-     * @brief The highest value dice can have.
-     */
-    int dice_value;
-
-    /**
-     * @brief The max amount of dice that can be rolled at once.
-     */
-    int max_dice;
-
-    /**
-     * @brief The amount of time in seconds to wait before marking a user AFK.
-     */
-    int afk_timeout;
-
-    /**
-     * @brief Whether discord webhooks are enabled on this server.
-     */
-    bool webhook_enabled;
-
-    /**
-     * @brief Requires an https Webhook link, including both ID and Token in the link.
-     */
-    QString webhook_url;
-
-    /**
-     * @brief If the modcall buffer is sent as a file.
-     */
-    bool webhook_sendfile;
-
-    /**
      * @brief The server-wide global timer.
      */
     QTimer* timer;
 
-    /**
-     * @brief Loads values from config.ini.
-     */
-    void loadServerConfig();
-
-    /**
-     * @brief Loads the configuration files for commands into stringlists.
-     */
-    void loadCommandConfig();
-
-    /**
-     * @brief Returns a stringlist with the contents of a .txt file from config/text/.
-     *
-     * @param Name of the file to load.
-     */
-    QStringList loadConfigFile(QString filename);
 
     QStringList getCursedCharsTaken(AOClient* client, QStringList chars_taken);
-
-    /**
-     * @brief List holding the contents of 8ball.txt, used by /8ball.
-     */
-    QStringList magic_8ball_answers;
-
-    /**
-     * @brief List holding the contents of praise.txt, used by AOClient::getReprimand.
-     */
-    QStringList praise_list;
-
-    /**
-     * @brief List holding the contents of reprimands.txt, used by AOClient::getReprimand.
-     */
-    QStringList reprimands_list;
-
-    /**
-     * @brief List holding the contents of gimp.txt, used by AOClient::cmdGimp.
-     */
-    QStringList gimp_list;
-
-    /**
-     * @brief Integer representing the maximum number of clients allowed to connect from the same IP
-     */
-    int multiclient_limit;
-
-    /**
-     * @brief Integer representing the maximum amount of characters an IC or OOC message can contain.
-     */
-    int max_chars;
 
     /**
      * @brief Timer until the next IC message can be sent.
@@ -312,56 +201,6 @@ class Server : public QObject {
      * @brief If false, IC messages will be rejected.
      */
     bool can_send_ic_messages = true;
-
-    /**
-     * @brief The minimum time between IC messages, in milliseconds.
-     */
-    int message_floodguard;
-
-    /**
-     * @brief Whether password requirements are enabled.
-     */
-    bool password_requirements = true;
-
-    /**
-     * @brief The minimum length passwords can be.
-     */
-    int password_minimum_length;
-
-    /**
-     * @brief The maximum length passwords can be.
-     */
-    int password_maximum_length;
-
-    /**
-     * @brief Whether passwords must be mixed case.
-     */
-    bool password_require_mixed_case = true;
-
-    /**
-     * @brief Whether passwords must contain numbers.
-     */
-    bool password_require_numbers = true;
-
-    /**
-     * @brief Whether passwords must contain special characters.
-     */
-    bool password_require_special_characters = true;
-
-    /**
-     * @brief Whether passwords can contain the associated username.
-     */
-    bool password_can_contain_username = false;
-
-    /**
-     * @brief URL send to the client during handshake to set the remote repository URL.
-     */
-    QUrl asset_url;
-
-    /**
-     * @brief Opional text to be send with the Discord embeed. Can be used to configure pings.
-     */
-    QString webhook_content;
 
   public slots:
     /**

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -88,7 +88,7 @@ void AOClient::handlePacket(AOPacket packet)
         if (is_afk)
             sendServerMessage("You are no longer AFK.");
         is_afk = false;
-        afk_timer->start(server->afk_timeout * 1000);
+        afk_timer->start(ConfigManager::afkTimeout() * 1000);
     }
 
     if (packet.contents.length() < info.minArgs) {
@@ -291,17 +291,17 @@ void AOClient::calculateIpid()
 
 void AOClient::sendServerMessage(QString message)
 {
-    sendPacket("CT", {server->server_name, message, "1"});
+    sendPacket("CT", {ConfigManager::serverName(), message, "1"});
 }
 
 void AOClient::sendServerMessageArea(QString message)
 {
-    server->broadcast(AOPacket("CT", {server->server_name, message, "1"}), current_area);
+    server->broadcast(AOPacket("CT", {ConfigManager::serverName(), message, "1"}), current_area);
 }
 
 void AOClient::sendServerBroadcast(QString message)
 {
-    server->broadcast(AOPacket("CT", {server->server_name, message, "1"}));
+    server->broadcast(AOPacket("CT", {ConfigManager::serverName(), message, "1"}));
 }
 
 bool AOClient::checkAuth(unsigned long long acl_mask)
@@ -318,12 +318,14 @@ bool AOClient::checkAuth(unsigned long long acl_mask)
         else if (!authenticated) {
             return false;
         }
-        if (server->auth_type == "advanced") {
+        switch (ConfigManager::authType()) {
+        case DataTypes::AuthType::SIMPLE:
+            return authenticated;
+            break;
+        case DataTypes::AuthType::ADVANCED:
             unsigned long long user_acl = server->db_manager->getACL(moderator_name);
             return (user_acl & acl_mask) != 0;
-        }
-        else if (server->auth_type == "simple") {
-            return authenticated;
+            break;
         }
     }
     return true;

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -48,12 +48,8 @@ AreaData::AreaData(QString p_name, int p_index) :
     m_toggleMusic = areas_ini.value("toggle_music", "true").toBool();
     m_shownameAllowed = areas_ini.value("shownames_allowed", "true").toBool();
     areas_ini.endGroup();
-    QSettings config_ini("config/config.ini", QSettings::IniFormat);
-    config_ini.setIniCodec("UTF-8");
-    config_ini.beginGroup("Options");
-    int log_size = config_ini.value("logbuffer", 50).toInt();
-    QString l_logType = config_ini.value("logger","modcall").toString();
-    config_ini.endGroup();
+    int log_size = ConfigManager::logBuffer();
+    DataTypes::LogType l_logType = ConfigManager::loggingType();
     if (log_size == 0)
         log_size = 500;
     m_logger = new Logger(m_name, log_size, l_logType);

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -261,7 +261,7 @@ void AOClient::cmdBgLock(int argc, QStringList argv)
         area->toggleBgLock();
     };
 
-    server->broadcast(AOPacket("CT", {server->server_name, current_char + " locked the background.", "1"}), current_area);
+    server->broadcast(AOPacket("CT", {ConfigManager::serverName(), current_char + " locked the background.", "1"}), current_area);
 }
 
 void AOClient::cmdBgUnlock(int argc, QStringList argv)
@@ -272,7 +272,7 @@ void AOClient::cmdBgUnlock(int argc, QStringList argv)
         area->toggleBgLock();
     };
 
-    server->broadcast(AOPacket("CT", {server->server_name, current_char + " unlocked the background.", "1"}), current_area);
+    server->broadcast(AOPacket("CT", {ConfigManager::serverName(), current_char + " unlocked the background.", "1"}), current_area);
 }
 
 void AOClient::cmdStatus(int argc, QStringList argv)
@@ -282,7 +282,7 @@ void AOClient::cmdStatus(int argc, QStringList argv)
 
     if (area->changeStatus(arg)) {
         arup(ARUPType::STATUS, true);
-        server->broadcast(AOPacket("CT", {server->server_name, current_char + " changed status to " + arg.toUpper(), "1"}), current_area);
+        server->broadcast(AOPacket("CT", {ConfigManager::serverName(), current_char + " changed status to " + arg.toUpper(), "1"}), current_area);
     } else {
         sendServerMessage("That does not look like a valid status. Valid statuses are " + AreaData::map_statuses.keys().join(", "));
     }

--- a/core/src/commands/authentication.cpp
+++ b/core/src/commands/authentication.cpp
@@ -26,8 +26,9 @@ void AOClient::cmdLogin(int argc, QStringList argv)
         sendServerMessage("You are already logged in!");
         return;
     }
-    if (server->auth_type == "simple") {
-        if (server->modpass == "") {
+    switch (ConfigManager::authType()) {
+    case DataTypes::AuthType::SIMPLE:
+        if (ConfigManager::modpass() == "") {
             sendServerMessage("No modpass is set. Please set a modpass before logging in.");
             return;
         }
@@ -36,17 +37,18 @@ void AOClient::cmdLogin(int argc, QStringList argv)
             is_logging_in = true;
             return;
         }
-    }
-    else if (server->auth_type == "advanced") {
+        break;
+    case DataTypes::AuthType::ADVANCED:
         sendServerMessage("Entering login prompt.\nPlease enter your username and password.");
         is_logging_in = true;
         return;
+        break;
     }
 }
 
 void AOClient::cmdChangeAuth(int argc, QStringList argv)
 {
-    if (server->auth_type == "simple") {
+    if (ConfigManager::authType() == DataTypes::AuthType::SIMPLE) {
         change_auth_started = true;
         sendServerMessage("WARNING!\nThis command will change how logging in as a moderator works.\nOnly proceed if you know what you are doing\nUse the command /rootpass to set the password for your root account.");
     }
@@ -64,10 +66,7 @@ void AOClient::cmdSetRootPass(int argc, QStringList argv)
 
     sendServerMessage("Changing auth type and setting root password.\nLogin again with /login root [password]");
     authenticated = false;
-    QSettings settings("config/config.ini", QSettings::IniFormat);
-    settings.beginGroup("Options");
-    settings.setValue("auth", "advanced");
-    server->auth_type = "advanced";
+    ConfigManager::setAuthType(DataTypes::AuthType::ADVANCED);
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
     qsrand(QDateTime::currentMSecsSinceEpoch());

--- a/core/src/commands/casing.cpp
+++ b/core/src/commands/casing.cpp
@@ -170,7 +170,7 @@ void AOClient::cmdPauseTestimony(int argc, QStringList argv)
 
 void AOClient::cmdAddStatement(int argc, QStringList argv)
 {
-    if (server->areas[current_area]->statement() < server->maximum_statements) {
+    if (server->areas[current_area]->statement() < ConfigManager::maxStatements()) {
         server->areas[current_area]->setTestimonyRecording(AreaData::TestimonyRecording::ADD);
         sendServerMessage("The next IC-Message will be inserted into the testimony.");
     }
@@ -248,7 +248,7 @@ void AOClient::cmdLoadTestimony(int argc, QStringList argv)
     QTextStream in(&file);
     in.setCodec("UTF-8");
     while (!in.atEnd()) {
-        if (testimony_lines <= server->maximum_statements) {
+        if (testimony_lines <= ConfigManager::maxStatements()) {
             QString line = in.readLine();
             QStringList packet = line.split("#");
             area->addStatement(area->testimony().size(), packet);

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -80,9 +80,9 @@ void AOClient::diceThrower(int argc, QStringList argv, bool p_roll)
     int dice = 1;
     QStringList results;
     if (argc >= 1)
-        sides = qBound(1, argv[0].toInt(), server->dice_value);
+        sides = qBound(1, argv[0].toInt(), ConfigManager::diceMaxValue());
     if (argc == 2)
-        dice = qBound(1, argv[1].toInt(), server->max_dice);
+        dice = qBound(1, argv[1].toInt(), ConfigManager::diceMaxDice());
     for (int i = 1; i <= dice; i++) {
         results.append(QString::number(AOClient::genRand(1, sides)));
     }
@@ -163,44 +163,44 @@ long long AOClient::parseTime(QString input)
 QString AOClient::getReprimand(bool positive)
 {
     if (positive) {
-        return server->praise_list[genRand(0, server->praise_list.size() - 1)];
+        return ConfigManager::praiseList()[genRand(0, ConfigManager::praiseList().size() - 1)];
         }
     else {
-        return server->reprimands_list[genRand(0, server->reprimands_list.size() - 1)];
+        return ConfigManager::reprimandsList()[genRand(0, ConfigManager::reprimandsList().size() - 1)];
         }
 }
 
 bool AOClient::checkPasswordRequirements(QString username, QString password)
 {
     QString decoded_password = decodeMessage(password);
-    if (!server->password_requirements)
+    if (!ConfigManager::passwordRequirements())
         return true;
 
-    if (server->password_minimum_length > decoded_password.length())
+    if (ConfigManager::passwordMinLength() > decoded_password.length())
         return false;
 
-    if (server->password_maximum_length < decoded_password.length() && server->password_maximum_length != 0)
+    if (ConfigManager::passwordMaxLength() < decoded_password.length() && ConfigManager::passwordMaxLength() != 0)
         return false;
 
-    else if (server->password_require_mixed_case) {
+    else if (ConfigManager::passwordRequireMixCase()) {
         if (decoded_password.toLower() == decoded_password)
             return false;
         if (decoded_password.toUpper() == decoded_password)
             return false;
     }
-    else if (server->password_require_numbers) {
+    else if (ConfigManager::passwordRequireNumbers()) {
         QRegularExpression regex("[0123456789]");
         QRegularExpressionMatch match = regex.match(decoded_password);
         if (!match.hasMatch())
             return false;
     }
-    else if (server->password_require_special_characters) {
+    else if (ConfigManager::passwordRequireSpecialCharacters()) {
         QRegularExpression regex("[~!@#$%^&*_-+=`|\\(){}\[]:;\"'<>,.?/]");
         QRegularExpressionMatch match = regex.match(decoded_password);
         if (!match.hasMatch())
             return false;
     }
-    else if (!server->password_can_contain_username) {
+    else if (!ConfigManager::passwordCanContainUsername()) {
         if (decoded_password.contains(username))
             return false;
     }

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -411,7 +411,7 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
 
 void AOClient::cmdReload(int argc, QStringList argv)
 {
-    ConfigManager::reloadConfigSettings();
+    ConfigManager::reloadSettings();
     emit server->reloadRequest(ConfigManager::serverName(), ConfigManager::serverDescription());
     sendServerMessage("Reloaded configurations");
 }

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -53,11 +53,13 @@ void AOClient::cmdBan(int argc, QStringList argv)
     bool ban_logged = false;
     int kick_counter = 0;
 
-    if (server->auth_type == "advanced") {
-        ban.moderator = moderator_name;
-    }
-    else {
+    switch (ConfigManager::authType()) {
+    case DataTypes::AuthType::SIMPLE:
         ban.moderator = "moderator";
+        break;
+    case DataTypes::AuthType::ADVANCED:
+        ban.moderator = moderator_name;
+        break;
     }
 
     for (AOClient* client : server->getClientsByIpid(ban.ipid)) {
@@ -117,7 +119,7 @@ void AOClient::cmdMods(int argc, QStringList argv)
     for (AOClient* client : server->clients) {
         if (client->authenticated) {
             entries << "---";
-            if (server->auth_type != "simple")
+            if (ConfigManager::authType() != DataTypes::AuthType::SIMPLE)
                 entries << "Moderator: " + client->moderator_name;
             entries << "OOC name: " + client->ooc_name;
             entries << "ID: " + QString::number(client->id);
@@ -148,12 +150,12 @@ void AOClient::cmdHelp(int argc, QStringList argv)
 void AOClient::cmdMOTD(int argc, QStringList argv)
 {
     if (argc == 0) {
-        sendServerMessage("=== MOTD ===\r\n" + server->MOTD + "\r\n=============");
+        sendServerMessage("=== MOTD ===\r\n" + ConfigManager::motd() + "\r\n=============");
     }
     else if (argc > 0) {
         if (checkAuth(ACLFlags.value("MOTD"))) {
             QString MOTD = argv.join(" ");
-            server->MOTD = MOTD;
+            ConfigManager::setMotd(MOTD);
             sendServerMessage("MOTD has been changed.");
         }
         else {
@@ -409,9 +411,8 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
 
 void AOClient::cmdReload(int argc, QStringList argv)
 {
-    server->loadServerConfig();
-    server->loadCommandConfig();
-    emit server->reloadRequest(server->server_name, server->server_desc);
+    ConfigManager::reloadConfigSettings();
+    emit server->reloadRequest(ConfigManager::serverName(), ConfigManager::serverDescription());
     sendServerMessage("Reloaded configurations");
 }
 

--- a/core/src/commands/roleplay.cpp
+++ b/core/src/commands/roleplay.cpp
@@ -161,12 +161,12 @@ void AOClient::cmdNoteCardReveal(int argc, QStringList argv)
 
 void AOClient::cmd8Ball(int argc, QStringList argv)
 {
-    if (server->magic_8ball_answers.isEmpty()) {
+    if (ConfigManager::magic8BallAnswers().isEmpty()) {
         qWarning() << "8ball.txt is empty!";
         sendServerMessage("8ball.txt is empty.");
         }
     else {
-        QString response = server->magic_8ball_answers[(genRand(1, server->magic_8ball_answers.size() - 1))];
+        QString response = ConfigManager::magic8BallAnswers()[(genRand(1, ConfigManager::magic8BallAnswers().size() - 1))];
         QString sender_name = ooc_name;
         QString sender_message = argv.join(" ");
 

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -17,179 +17,413 @@
 //////////////////////////////////////////////////////////////////////////////////////
 #include "include/config_manager.h"
 
-// Validate and set up the config
-bool ConfigManager::initConfig()
+ConfigManager::server_settings* ConfigManager::m_settings = new server_settings();
+
+bool ConfigManager::verifyServerConfig()
 {
-    QSettings config("config/config.ini", QSettings::IniFormat);
-    config.setIniCodec("UTF-8");
-    QFileInfo config_dir_info("config/");
-    if (!config_dir_info.exists() || !config_dir_info.isDir()) {
-        qCritical() << "Config directory doesn't exist!";
-        return false;
+    // Verify directories
+    QStringList l_directories{"config/", "config/text/"};
+    for (QString l_directory : l_directories) {
+        if (!dirExists(QFileInfo(l_directory))) {
+                qCritical() << l_directory + " does not exist!";
+                return false;
+        }
     }
 
-    // Check that areas, characters, and music lists all exist
-    QFileInfo areas_info("config/areas.ini");
-    QFileInfo characters_info("config/characters.txt");
-    QFileInfo music_info("config/music.txt");
-    QFileInfo backgrounds_info("config/backgrounds.txt");
-
-    if (!fileExists(&areas_info)) {
-        qCritical() << "areas.ini doesn't exist!";
-        return false;
-    }
-    else {
-        QSettings areas_ini("config/areas.ini", QSettings::IniFormat);
-        areas_ini.setIniCodec("UTF-8");
-        if (areas_ini.childGroups().length() < 1) {
-            qCritical() << "areas.ini is invalid!";
+    // Verify config files
+    QStringList l_config_files{"config/config.ini", "config/areas.ini", "config/backgrounds.txt", "config/characters.txt", "config/music.txt",
+                              "config/text/8ball.txt", "config/text/gimp.txt", "config/text/praise.txt", "config/text/reprimands.txt"};
+    for (QString l_file : l_config_files) {
+        if (!fileExists(QFileInfo(l_file))) {
+            qCritical() << l_file + " does not exist!";
             return false;
         }
     }
-    if (!fileExists(&characters_info)) {
-        qCritical() << "characters.txt doesn't exist!";
-        return false;
-    }
-    if (!fileExists(&music_info)) {
-        qCritical() << "music.txt doesn't exist!";
-        return false;
-    }
-    if (!fileExists(&backgrounds_info)) {
-        qCritical() << "backgrounds.txt doesn't exist!";
-        return false;
-    }
 
-    config.beginGroup("Info");
-    QString config_version = config.value("version", "none").toString();
-    config.endGroup();
-    if (config_version == "none") {
-        QFileInfo check_file("config/config.ini");
-        if (!fileExists(&check_file)) {
-            qCritical() << "config.ini doesn't exist!";
-        }
-        else {
-            qCritical() << "config.ini is invalid!";
-        }
+    // Verify areas
+    QSettings l_areas_ini("config/areas.ini", QSettings::IniFormat);
+    l_areas_ini.setIniCodec("UTF-8");
+    if (l_areas_ini.childGroups().length() < 1) {
+        qCritical() << "areas.ini is invalid!";
         return false;
-    }
-    else if (config_version != QString::number(CONFIG_VERSION)) {
-        bool version_number_is_valid;
-        int current_version = config_version.toInt(&version_number_is_valid);
-        if (version_number_is_valid) {
-            if (updateConfig(current_version))
-                qWarning() << "config.ini was out of date, and has been updated. Please review the changes, and restart the server.";
-            else
-                qCritical() << "config.ini is invalid!";
-        }
-        else
-            qCritical() << "config.ini is invalid!"; // Version number isn't a number at all
-                                                     // This means the config is invalid
-        return false;
-    }
-    config.beginGroup("Options");
-    QString auth_type = config.value("auth", "simple").toString();
-    config.endGroup();
-    if (!(auth_type == "simple" || auth_type == "advanced")) {
-        qCritical() << "config.ini is invalid!";
-        return false;
-    }
-    if (!(verifyCommandConfig())) {
-        return false;
-    }
-
-    else {
-        // Config is valid and up to date, so let's go ahead
-        return true;
-    }
-}
-
-// Ensure version continuity with config versions
-bool ConfigManager::updateConfig(int current_version)
-{
-    QSettings config("config/config.ini", QSettings::IniFormat);
-    config.setIniCodec("UTF-8");
-    if (current_version > CONFIG_VERSION) {
-        // Config version is newer than the latest version, and the config is
-        // invalid This could also mean the server is out of date, and the user
-        // should be shown a relevant message Regardless, regen the config
-        // anyways
-        return false;
-    }
-    else if (current_version < 0) {
-        // Negative version number? Invalid!
-        return false;
-    }
-    else {
-        // Update the config as needed using a switch. This is nice because we
-        // can fall through as we go up the version ladder.
-        switch (current_version) {
-        case 0: // Version 0 doesn't actually exist, but we should check for it
-                // just in case
-        case 1:
-            config.beginGroup("Info");
-            config.setValue("version", CONFIG_VERSION);
-            config.endGroup();
-            break; // This is the newest version, and nothing more needs to be
-                   // done
-        }
-        return true;
-    }
-}
-
-// Validate and retriever settings related to advertising and the server
-bool ConfigManager::loadServerSettings(server_settings* settings)
-{
-    QSettings config("config/config.ini", QSettings::IniFormat);
-    config.setIniCodec("UTF-8");
-    bool port_conversion_success;
-    bool ws_port_conversion_success;
-    bool local_port_conversion_success;
-    config.beginGroup("Options");
-    settings->ms_ip =
-        config.value("ms_ip", "master.aceattorneyonline.com").toString();
-    settings->port =
-        config.value("port", "27016").toInt(&port_conversion_success);
-    settings->ws_port =
-        config.value("webao_port", "27017").toInt(&ws_port_conversion_success);
-    settings->ms_port =
-        config.value("ms_port", "27016").toInt(&local_port_conversion_success);
-    settings->name = config.value("server_name", "My First Server").toString();
-    settings->description =
-        config.value("server_description", "This is my flashy new server")
-            .toString();
-    config.endGroup();
-    if (!port_conversion_success || !ws_port_conversion_success ||
-        !local_port_conversion_success) {
-        return false;
-    }
-    else {
-        config.beginGroup("Options");
-        // Will be true of false depending on the key
-        settings->advertise_server =
-            (config.value("advertise", "true").toString() == "true");
-
-        if (config.value("webao_enable", "true").toString() != "true")
-            settings->ws_port = -1;
-        config.endGroup();
-
-        return true;
-    }
-}
-
-bool ConfigManager::fileExists(QFileInfo* file)
-{
-    return (file->exists() && file->isFile());
-}
-
-bool ConfigManager::verifyCommandConfig()
-{
-    QStringList filelist = {"8ball", "praise", "reprimands", "gimp"};
-    foreach (QString filename, filelist) {
-        QFileInfo file("config/text/" + filename + ".txt");
-        if (!(fileExists(&file))) {
-            qCritical() << (filename + ".txt doesn't exist!");
-            return false;
-        }
     }
     return true;
+}
+
+bool ConfigManager::loadConfigSettings()
+{
+    QSettings l_config("config/config.ini", QSettings::IniFormat);
+    l_config.setIniCodec("UTF-8");
+    l_config.beginGroup("Options");
+    bool ok;
+    m_settings->ms_port = l_config.value("ms_port", "27016").toInt(&ok);
+    if (!ok) {
+        qCritical("ms_port is not a valid port!");
+        return false;
+    }
+    m_settings->port = l_config.value("port", "27016").toInt(&ok);
+    if (!ok) {
+        qCritical("port is not a valid port!");
+        return false;
+    }
+    m_settings->webao_enable = l_config.value("webao_enable", "true").toBool();
+    if (!m_settings->webao_enable) {
+        m_settings->webao_port = -1;
+    }
+    else {
+        m_settings->webao_port = l_config.value("webao_port", "27017").toInt(&ok);
+        if (!ok) {
+            qCritical("webao_port is not a valid port!");
+            return false;
+        }
+    }
+    m_settings->ms_ip = l_config.value("ms_ip", "master.aceattorneyonline.com").toString();
+    m_settings->advertise = l_config.value("advertise", "true").toBool();
+    l_config.endGroup();
+
+    if (reloadConfigSettings())
+        return true;
+    else
+        return false;
+}
+
+bool ConfigManager::reloadConfigSettings()
+{
+    QSettings l_config("config/config.ini", QSettings::IniFormat);
+    l_config.setIniCodec("UTF-8");
+    l_config.beginGroup("Options");
+    bool ok;
+
+    // Options
+    m_settings->max_players = l_config.value("max_players", "100").toInt(&ok);
+    if (!ok) {
+        qWarning("max_players is not an int!");
+        m_settings->max_players = 100;
+    }
+    m_settings->server_description = l_config.value("server_description", "This is my flashy new server!").toString();
+    m_settings->server_name = l_config.value("server_name", "An Unnamed Server").toString();
+    m_settings->motd = l_config.value("motd", "MOTD not set").toString();
+    QString l_auth = l_config.value("auth", "simple").toString();
+    if (l_auth == "simple" || l_auth == "advanced") {
+        m_settings->auth = toDataType<DataTypes::AuthType>(l_auth);
+    }
+    else {
+        qCritical("auth is not a valid auth type!");
+        return false;
+    }
+    m_settings->modpass = l_config.value("modpass", "changeme").toString();
+    m_settings->logbuffer = l_config.value("logbuffer", "500").toInt(&ok);
+    if (!ok) {
+        qWarning("logbuffer is not an int!");
+        m_settings->logbuffer = 500;
+    }
+    QString l_log = l_config.value("logging", "modcall").toString();
+    if (l_log == "modcall" || l_log == "full") {
+        m_settings->logging = toDataType<DataTypes::LogType>(l_log);
+    }
+    else {
+        qWarning("logging is not a valid log type!");
+        m_settings->logging = DataTypes::LogType::MODCALL;
+    }
+    m_settings->maximum_statements = l_config.value("maximum_statements", "10").toInt(&ok);
+    if (!ok) {
+        qWarning("maximum_statements is not an int!");
+        m_settings->maximum_statements = 10;
+    }
+    m_settings->multiclient_limit = l_config.value("multiclient_limit", "15").toInt(&ok);
+    if (!ok) {
+        qWarning("multiclient_limit is not an int!");
+        m_settings->multiclient_limit = 15;
+    }
+    m_settings->maximum_characters = l_config.value("maximum_characters", "256").toInt(&ok);
+    if (!ok) {
+        qWarning("maximum_characters is not an int!");
+        m_settings->maximum_characters = 256;
+    }
+    m_settings->message_floodguard = l_config.value("message_floodguard", "250").toInt(&ok);
+    if (!ok) {
+        qWarning("message_floodguard is not an in!");
+        m_settings->message_floodguard = 250;
+    }
+    m_settings->asset_url = l_config.value("asset_url", "").toString().toUtf8();
+    if (!m_settings->asset_url.isValid()) {
+        qWarning("asset_url is not a valid url!");
+        m_settings->asset_url = NULL;
+    }
+    l_config.endGroup();
+
+    // Dice
+    l_config.beginGroup("Dice");
+    m_settings->max_value = l_config.value("max_value", "100").toInt(&ok);
+    if (!ok) {
+        qWarning("max_value is not an int!");
+        m_settings->max_value = 100;
+    }
+    m_settings->max_dice = l_config.value("max_dice", "100").toInt(&ok);
+    if (!ok) {
+        qWarning("max_dice is not an int!");
+        m_settings->max_dice = 100;
+    }
+    l_config.endGroup();
+
+    // Discord
+    l_config.beginGroup("Discord");
+    m_settings->webhook_enabled = l_config.value("webhook_enabled", "false").toBool();
+    m_settings->webhook_url = l_config.value("webhook_url", "Your webhook url here.").toString();
+    m_settings->webhook_sendfile = l_config.value("webhook_sendfile", "false").toBool();
+    m_settings->webhook_content = l_config.value("webhook_content", "").toString();
+    l_config.endGroup();
+
+    // Password
+    l_config.beginGroup("Password");
+    m_settings->password_requirements = l_config.value("password_requirements", "true").toBool();
+    m_settings->pass_min_length = l_config.value("pass_min_length", "8").toInt(&ok);
+    if (!ok) {
+        qWarning("pass_min_length is not an int!");
+        m_settings->pass_min_length = 8;
+    }
+    m_settings->pass_max_length = l_config.value("pass_max_length", "0").toInt(&ok);
+    if (!ok) {
+        qWarning("pass_max_length is not an int!");
+        m_settings->pass_max_length = 0;
+    }
+    m_settings->pass_required_mix_case = l_config.value("pass_required_mix_case", "true").toBool();
+    m_settings->pass_required_numbers = l_config.value("pass_required_numbers", "true").toBool();
+    m_settings->pass_required_special = l_config.value("pass_required_special", "true").toBool();
+    m_settings->pass_can_contain_username = l_config.value("pass_can_contain_username", "false").toBool();
+
+    m_settings->afk_timeout = l_config.value("afk_timeout", "300").toInt(&ok);
+    if (!ok) {
+        qWarning("afk_timeout is not an int!");
+        m_settings->afk_timeout = 300;
+    }
+    l_config.endGroup();
+
+    m_settings->magic_8ball_answers = (loadConfigFile("8ball"));
+    m_settings->praise_list = (loadConfigFile("praise"));
+    m_settings->reprimands_list = (loadConfigFile("reprimands"));
+    m_settings->gimp_list = (loadConfigFile("gimp"));
+
+    return true;
+}
+
+QStringList ConfigManager::loadConfigFile(const QString filename)
+{
+    QStringList stringlist;
+    QFile file("config/text/" + filename + ".txt");
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    while (!(file.atEnd())) {
+        stringlist.append(file.readLine().trimmed());
+    }
+    file.close();
+    return stringlist;
+}
+
+bool ConfigManager::advertiseServer()
+{
+    return m_settings->advertise;
+}
+
+int ConfigManager::maxPlayers()
+{
+    return m_settings->max_players;
+}
+
+QString ConfigManager::masterServerIP()
+{
+    return m_settings->ms_ip;
+}
+
+int ConfigManager::masterServerPort()
+{
+    return m_settings->ms_port;
+}
+
+int ConfigManager::serverPort()
+{
+    return m_settings->port;
+}
+
+QString ConfigManager::serverDescription()
+{
+    return m_settings->server_description;
+}
+
+QString ConfigManager::serverName()
+{
+    return m_settings->server_name;
+}
+
+QString ConfigManager::motd()
+{
+    return m_settings->motd;
+}
+
+bool ConfigManager::webaoEnabled()
+{
+    return m_settings->webao_enable;
+}
+
+int ConfigManager::webaoPort()
+{
+    return m_settings->webao_port;
+}
+
+DataTypes::AuthType ConfigManager::authType()
+{
+    return m_settings->auth;
+}
+
+QString ConfigManager::modpass()
+{
+    return m_settings->modpass;
+}
+
+int ConfigManager::logBuffer()
+{
+    return m_settings->logbuffer;
+}
+
+DataTypes::LogType ConfigManager::loggingType()
+{
+    return m_settings->logging;
+}
+
+int ConfigManager::maxStatements()
+{
+    return m_settings->maximum_statements;
+}
+int ConfigManager::multiClientLimit()
+{
+    return m_settings->multiclient_limit;
+}
+
+int ConfigManager::maxCharacters()
+{
+    return m_settings->maximum_characters;
+}
+
+int ConfigManager::messageFloodguard()
+{
+    return m_settings->message_floodguard;
+}
+
+QUrl ConfigManager::assetUrl()
+{
+    return m_settings->asset_url;
+}
+
+int ConfigManager::diceMaxValue()
+{
+    return m_settings->max_value;
+}
+
+int ConfigManager::diceMaxDice()
+{
+    return m_settings->max_dice;
+}
+
+bool ConfigManager::discordWebhookEnabled()
+{
+    return m_settings->webao_enable;
+}
+
+QString ConfigManager::discordWebhookUrl()
+{
+    return m_settings->webhook_url;
+}
+
+QString ConfigManager::discordWebhookContent()
+{
+    return m_settings->webhook_content;
+}
+
+bool ConfigManager::discordWebhookSendFile()
+{
+    return m_settings->webhook_sendfile;
+}
+
+bool ConfigManager::passwordRequirements()
+{
+    return m_settings->password_requirements;
+}
+
+int ConfigManager::passwordMinLength()
+{
+    return m_settings->pass_min_length;
+}
+
+int ConfigManager::passwordMaxLength()
+{
+    return m_settings->pass_max_length;
+}
+
+bool ConfigManager::passwordRequireMixCase()
+{
+    return m_settings->pass_required_mix_case;
+}
+
+bool ConfigManager::passwordRequireNumbers()
+{
+    return m_settings->pass_required_numbers;
+}
+
+bool ConfigManager::passwordRequireSpecialCharacters()
+{
+    return m_settings->pass_required_special;
+}
+
+bool ConfigManager::passwordCanContainUsername()
+{
+    return m_settings->pass_can_contain_username;
+}
+
+int ConfigManager::afkTimeout()
+{
+    return m_settings->afk_timeout;
+}
+
+void ConfigManager::setAuthType(const DataTypes::AuthType f_auth)
+{
+    QSettings l_config("config/config.ini", QSettings::IniFormat);
+    l_config.setIniCodec("UTF-8");
+    l_config.beginGroup("Options");
+    l_config.setValue("auth", fromDataType<DataTypes::AuthType>(f_auth).toLower());
+
+    m_settings->auth = f_auth;
+}
+
+QStringList ConfigManager::magic8BallAnswers()
+{
+    return m_settings->magic_8ball_answers;
+}
+
+QStringList ConfigManager::praiseList()
+{
+    return m_settings->praise_list;
+}
+
+QStringList ConfigManager::reprimandsList()
+{
+    return m_settings->reprimands_list;
+}
+
+QStringList ConfigManager::gimpList()
+{
+    return m_settings->gimp_list;
+}
+
+void ConfigManager::setMotd(const QString f_motd)
+{
+    m_settings->motd = f_motd;
+}
+
+bool ConfigManager::fileExists(const QFileInfo &f_file)
+{
+    return (f_file.exists() && f_file.isFile());
+}
+
+bool ConfigManager::dirExists(const QFileInfo &f_dir)
+{
+    return (f_dir.exists() && f_dir.isDir());
 }

--- a/core/src/discord.cpp
+++ b/core/src/discord.cpp
@@ -19,12 +19,13 @@
 
 void Discord::postModcallWebhook(QString name, QString reason, int current_area)
 {
-    if (!QUrl (server->webhook_url).isValid()) {
+    if (!QUrl (ConfigManager::discordWebhookUrl()).isValid()) {
         qWarning() << "Invalid webhook url!";
         return;
     }
 
-    QNetworkRequest request(QUrl (server->webhook_url));
+    QNetworkRequest request;
+    request.setUrl(QUrl (ConfigManager::discordWebhookUrl()));
     QNetworkAccessManager* nam = new QNetworkAccessManager();
     connect(nam, &QNetworkAccessManager::finished,
             this, &Discord::onFinish);
@@ -42,12 +43,12 @@ void Discord::postModcallWebhook(QString name, QString reason, int current_area)
     };
     jsonArray.append(jsonObject);
     json["embeds"] = jsonArray;
-    if (!server->webhook_content.isEmpty())
-      json["content"] = server->webhook_content;
+    if (!ConfigManager::discordWebhookContent().isEmpty())
+      json["content"] = ConfigManager::discordWebhookContent();
 
     nam->post(request, QJsonDocument(json).toJson());
 
-    if (server->webhook_sendfile) {
+    if (ConfigManager::discordWebhookSendFile()) {
         QHttpMultiPart* construct = new QHttpMultiPart();
         request.setHeader(QNetworkRequest::ContentTypeHeader, "multipart/form-data; boundary=" + construct->boundary());
 

--- a/core/src/logger.cpp
+++ b/core/src/logger.cpp
@@ -79,7 +79,7 @@ void Logger::addEntry(
     if (m_buffer.length() < m_maxLength) {
         m_buffer.enqueue(l_logEntry);
 
-        if (m_logType == "full") {
+        if (m_logType == DataTypes::LogType::FULL) {
            flush();
         }
     }
@@ -98,14 +98,13 @@ void Logger::flush()
 
     QFile l_logfile;
 
-    if (m_logType == "modcall") {
+    switch (m_logType) {
+    case DataTypes::LogType::MODCALL:
         l_logfile.setFileName(QString("logs/report_%1_%2.log").arg(m_areaName, (QDateTime::currentDateTime().toString("yyyy-MM-dd_hhmmss"))));
-    }
-    else if (m_logType == "full") {
+        break;
+    case DataTypes::LogType::FULL:
         l_logfile.setFileName(QString("logs/%1.log").arg(QDate::currentDate().toString("yyyy-MM-dd")));
-    }
-    else {
-        qCritical("Invalid logger set!");
+        break;
     }
 
     if (l_logfile.open(QIODevice::WriteOnly | QIODevice::Append)) {

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -61,11 +61,11 @@ void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacke
         version.minor = match.captured(3).toInt();
     }
 
-    sendPacket("PN", {QString::number(server->player_count), server->max_players});
+    sendPacket("PN", {QString::number(server->player_count), QString::number(ConfigManager::maxPlayers())});
     sendPacket("FL", feature_list);
 
-    if (server->asset_url.isValid()) {
-    QByteArray asset_url = server->asset_url.toEncoded(QUrl::EncodeSpaces);
+    if (ConfigManager::assetUrl().isValid()) {
+    QByteArray asset_url = ConfigManager::assetUrl().toEncoded(QUrl::EncodeSpaces);
     sendPacket("ASS", {asset_url});
     }
 }
@@ -115,7 +115,7 @@ void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPack
     sendPacket("DONE");
     sendPacket("BN", {area->background()});
   
-    sendServerMessage("=== MOTD ===\r\n" + server->MOTD + "\r\n=============");
+    sendServerMessage("=== MOTD ===\r\n" + ConfigManager::motd() + "\r\n=============");
 
     fullArup(); // Give client all the area data
     if (server->timer->isActive()) {
@@ -178,7 +178,7 @@ void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket pa
     area->updateLastICMessage(validated_packet.contents);
 
     server->can_send_ic_messages = false;
-    server->next_message_timer.start(server->message_floodguard);
+    server->next_message_timer.start(ConfigManager::messageFloodguard());
 }
 
 void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket packet)
@@ -189,7 +189,7 @@ void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket p
     }
 
     ooc_name = dezalgo(argv[0]).replace(QRegExp("\\[|\\]|\\{|\\}|\\#|\\$|\\%|\\&"), ""); // no fucky wucky shit here
-    if (ooc_name.isEmpty() || ooc_name == server->server_name) // impersonation & empty name protection
+    if (ooc_name.isEmpty() || ooc_name == ConfigManager::serverName()) // impersonation & empty name protection
         return;
 
     if (ooc_name.length() > 30) {
@@ -203,7 +203,7 @@ void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket p
     }
     
     QString message = dezalgo(argv[1]);
-    if (message.length() == 0 || message.length() > server->max_chars)
+    if (message.length() == 0 || message.length() > ConfigManager::maxCharacters())
         return;
     AOPacket final_packet("CT", {ooc_name, message, "0"});
     if(message.at(0) == '/') {
@@ -333,7 +333,7 @@ void AOClient::pktWebSocketIp(AreaData* area, int argc, QStringList argv, AOPack
                 multiclient_count++;
         }
 
-        if (multiclient_count > server->multiclient_limit) {
+        if (multiclient_count > ConfigManager::multiClientLimit()) {
             socket->close();
             return;
         }
@@ -348,7 +348,7 @@ void AOClient::pktModCall(AreaData* area, int argc, QStringList argv, AOPacket p
     }
     area->log(current_char, ipid, packet);
 
-    if (server->webhook_enabled) {
+    if (ConfigManager::discordWebhookEnabled()) {
         QString name = ooc_name;
         if (ooc_name.isEmpty())
             name = current_char;
@@ -536,7 +536,7 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     args.append(emote);
 
     // message text
-    if (incoming_args[4].toString().size() > server->max_chars)
+    if (incoming_args[4].toString().size() > ConfigManager::maxCharacters())
         return invalid;
 
     QString incoming_msg = dezalgo(incoming_args[4].toString().trimmed());
@@ -551,7 +551,7 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
     }
 
     if (is_gimped) {
-        QString gimp_message = server->gimp_list[(genRand(1, server->gimp_list.size() - 1))];
+        QString gimp_message = ConfigManager::gimpList()[(genRand(1, ConfigManager::gimpList().size() - 1))];
         incoming_msg = gimp_message;
     }
 
@@ -881,8 +881,9 @@ QString AOClient::decodeMessage(QString incoming_message)
 
 void AOClient::loginAttempt(QString message)
 {
-    if (server->auth_type == "simple") {
-        if (message == server->modpass) {
+    switch (ConfigManager::authType()) {
+    case DataTypes::AuthType::SIMPLE:
+        if (message == ConfigManager::modpass()) {
             sendPacket("AUTH", {"1"}); // Client: "You were granted the Disable Modcalls button."
             sendServerMessage("Logged in as a moderator."); // pre-2.9.1 clients are hardcoded to display the mod UI when this string is sent in OOC
             authenticated = true;
@@ -892,8 +893,8 @@ void AOClient::loginAttempt(QString message)
             sendServerMessage("Incorrect password.");
         }
         server->areas.value(current_area)->logLogin(current_char, ipid, authenticated, "moderator");
-    }
-    else if (server->auth_type == "advanced") {
+        break;
+    case DataTypes::AuthType::ADVANCED:
         QStringList login = message.split(" ");
         if (login.size() < 2) {
             sendServerMessage("You must specify a username and a password");
@@ -916,11 +917,8 @@ void AOClient::loginAttempt(QString message)
             sendServerMessage("Incorrect password.");
         }
         server->areas.value(current_area)->logLogin(current_char, ipid, authenticated, username);
+        break;
     }
-    else {
-            qWarning() << "config.ini has an unrecognized auth_type!";
-            sendServerMessage("Config.ini contains an invalid auth_type, please check your config.");
-        }
     sendServerMessage("Exiting login prompt.");
     is_logging_in = false;
     return;

--- a/core/src/testimony_recorder.cpp
+++ b/core/src/testimony_recorder.cpp
@@ -25,7 +25,7 @@ void AOClient::addStatement(QStringList packet)
     int c_statement = area->statement();
     if (c_statement >= -1) {
         if (area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING) {
-            if (c_statement <= server->maximum_statements) {
+            if (c_statement <= ConfigManager::maxStatements()) {
                 if (c_statement == -1)
                     packet[14] = "3";
                 else


### PR DESCRIPTION
Rewrites ConfigManager, which now loads and manages all config.ini values in addition to verifying server config files and directories. In addition, also adds a new DataTypes class for custom data types, as well as template function for converting between data types and QStrings.
Adds AuthType and LogType for server auth and logging values respectively. Changes every reference to these two config values to use the new types instead of QStrings, allowing for the use of switch statements, ensuring correct auth/logging types are used, and providing greater flexibility and readability. (For example, additional auth and logging modes can be added very easily).

Finally, this removes all config.ini loading from elsewhere in the code. ConfigManager is now the sole class for handling config.ini.