### PR TITLE
Make /mods only useable by moderators

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1987,7 +1987,7 @@ class AOClient : public QObject {
         {"randomchar",         {ACLFlags.value("NONE"),         0, &AOClient::cmdRandomChar}},
         {"switch",             {ACLFlags.value("NONE"),         1, &AOClient::cmdSwitch}},
         {"toggleglobal",       {ACLFlags.value("NONE"),         0, &AOClient::cmdToggleGlobal}},
-        {"mods",               {ACLFlags.value("NONE"),         0, &AOClient::cmdMods}},
+        {"mods",               {ACLFlags.value("MODCHAT"),      0, &AOClient::cmdMods}},
         {"help",               {ACLFlags.value("NONE"),         0, &AOClient::cmdHelp}},
         {"status",             {ACLFlags.value("NONE"),         1, &AOClient::cmdStatus}},
         {"forcepos",           {ACLFlags.value("CM"),           2, &AOClient::cmdForcePos}},


### PR DESCRIPTION
Makes /mods useable only by users with MODCHAT permissions, effectively making it mod-only. This is to prevent users from easily knowing when moderators are online, thus stopping them from evading moderation.