### PR TITLE
Prevent testimony messages containing "<" and ">".

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1905,6 +1905,15 @@ class AOClient : public QObject {
      */
     bool checkPasswordRequirements(QString username, QString password);
     
+    /**
+     * @brief Checks if a testimony contains '<' or '>'.
+     *
+     * @param message The IC Message that might contain unproper symbols.
+     *
+     * @return True if it contains '<' or '>' symbols, otherwise false.
+     */
+
+    bool checkTestimonySymbols(QString message);
     ///@}
 
     /**

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1912,8 +1912,7 @@ class AOClient : public QObject {
      *
      * @return True if it contains '<' or '>' symbols, otherwise false.
      */
-
-    bool checkTestimonySymbols(QString message);
+    bool checkTestimonySymbols(const QString& message);
     ///@}
 
     /**

--- a/core/src/testimony_recorder.cpp
+++ b/core/src/testimony_recorder.cpp
@@ -21,6 +21,9 @@
 
 void AOClient::addStatement(QStringList packet)
 {
+    if (checkTestimonySymbols(packet[4])) {
+        return;
+    }
     AreaData* area = server->areas[current_area];
     int c_statement = area->statement();
     if (c_statement >= -1) {
@@ -38,9 +41,9 @@ void AOClient::addStatement(QStringList packet)
             }
         }
         else if (area->testimonyRecording() == AreaData::TestimonyRecording::ADD) {
-               packet[14] = "1";
-               area->addStatement(c_statement, packet);
-               area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
+                packet[14] = "1";
+                area->addStatement(c_statement, packet);
+                area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
             }
             else {
                 sendServerMessage("Unable to add more statements. The maximum amount of statements has been reached.");
@@ -51,6 +54,9 @@ void AOClient::addStatement(QStringList packet)
 
 QStringList AOClient::updateStatement(QStringList packet)
 {
+    if (checkTestimonySymbols(packet[4])) {
+        return packet;
+    }
     AreaData* area = server->areas[current_area];
     int c_statement = area->statement();
     area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
@@ -69,4 +75,14 @@ void AOClient::clearTestimony()
 {
     AreaData* area = server->areas[current_area];
     area->clearTestimony();
+}
+
+bool AOClient::checkTestimonySymbols(QString message)
+{
+    if (message.contains('>') || message.contains('<')) {
+        sendServerMessage("Unable to add statements containing '>' or '<'.");
+        return true;
+    }
+    else
+        return false;
 }

--- a/core/src/testimony_recorder.cpp
+++ b/core/src/testimony_recorder.cpp
@@ -77,12 +77,11 @@ void AOClient::clearTestimony()
     area->clearTestimony();
 }
 
-bool AOClient::checkTestimonySymbols(QString message)
+bool AOClient::checkTestimonySymbols(const QString& message)
 {
     if (message.contains('>') || message.contains('<')) {
         sendServerMessage("Unable to add statements containing '>' or '<'.");
         return true;
     }
-    else
-        return false;
+    return false;
 }


### PR DESCRIPTION
And also add a space to some lines because they were 3 spaces for some reason.