### PR TITLE
Fix or suppress compiler warnings

### DIFF
--- a/core/include/discord.h
+++ b/core/include/discord.h
@@ -99,6 +99,26 @@ private:
      */
     QTimer* m_uptimePostTimer;
 
+    /**
+     * @brief Constructs a new JSON document for modcalls.
+     *
+     * @param f_name The name of the modcall sender.
+     * @param f_area The name of the area the modcall was sent from.
+     * @param f_reason The reason for the modcall.
+     *
+     * @return A JSON document for the modcall.
+     */
+    QJsonDocument constructModcallJson(const QString& f_name, const QString& f_area, const QString& f_reason) const;
+
+    /**
+     * @brief Constructs a new QHttpMultiPart document for log files.
+     *
+     * @param f_buffer The area's log buffer.
+     *
+     * @return A QHttpMultiPart containing the log file.
+     */
+    QHttpMultiPart* constructLogMultipart(const QQueue<QString>& f_buffer) const;
+
 private slots:
     /**
      * @brief Handles a network reply from a webhook POST request.
@@ -121,16 +141,7 @@ private slots:
      */
     void postMultipartWebhook(QHttpMultiPart& f_multipart);
 
-    /**
-     * @brief Constructs a new JSON document for modcalls.
-     *
-     * @param f_name The name of the modcall sender.
-     * @param f_area The name of the area the modcall was sent from.
-     * @param f_reason The reason for the modcall.
-     *
-     * @return A JSON document for the modcall.
-     */
-    QJsonDocument constructModcallJson(const QString& f_name, const QString& f_area, const QString& f_reason) const;
+
 
     /**
      * @brief Constructs a new JSON document for bans.
@@ -151,14 +162,6 @@ private slots:
      */
     QJsonDocument constructUptimeJson(const QString& f_timeExpired);
 
-    /**
-     * @brief Constructs a new QHttpMultiPart document for log files.
-     *
-     * @param f_buffer The area's log buffer.
-     *
-     * @return A QHttpMultiPart containing the log file.
-     */
-    QHttpMultiPart* constructLogMultipart(const QQueue<QString>& f_buffer) const;
 };
 
 #endif // DISCORD_H

--- a/core/include/logger.h
+++ b/core/include/logger.h
@@ -37,7 +37,7 @@ public:
      * @param f_max_length The maximum amount of entries the Logger can store at once.
      */
     Logger(QString f_area_name, int f_max_length, const DataTypes::LogType& f_logType_r) :
-         m_maxLength(f_max_length), m_areaName(f_area_name), m_logType(f_logType_r) {};
+        m_maxLength(f_max_length), m_areaName(f_area_name), m_logType(f_logType_r) {};
 
     /**
      *@brief Returns a copy of the logger's buffer.

--- a/core/include/logger.h
+++ b/core/include/logger.h
@@ -37,7 +37,7 @@ public:
      * @param f_max_length The maximum amount of entries the Logger can store at once.
      */
     Logger(QString f_area_name, int f_max_length, const DataTypes::LogType& f_logType_r) :
-        m_areaName(f_area_name), m_maxLength(f_max_length), m_logType(f_logType_r) {};
+         m_maxLength(f_max_length), m_areaName(f_area_name), m_logType(f_logType_r) {};
 
     /**
      *@brief Returns a copy of the logger's buffer.

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -41,7 +41,7 @@ void AOClient::clientData()
     QStringList all_packets = data.split("%");
     all_packets.removeLast(); // Remove the entry after the last delimiter
 
-    for (QString single_packet : all_packets) {
+    for (const QString &single_packet : qAsConst(all_packets)) {
         AOPacket packet(single_packet);
         handlePacket(packet);
     }
@@ -64,7 +64,7 @@ void AOClient::clientDisconnected()
 
     bool l_updateLocks = false;
 
-    for (AreaData* area : server->areas) {
+    for (AreaData* area : qAsConst(server->areas)) {
         l_updateLocks = l_updateLocks || area->removeOwner(id);
     }
 

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -133,7 +133,8 @@ void AOClient::changeArea(int new_area)
     if (character_taken) {
         sendPacket("DONE");
     }
-    for (QTimer* timer : server->areas[current_area]->timers()) {
+    const QList<QTimer*> timers = server->areas[current_area]->timers();
+    for (QTimer* timer : timers) {
         int timer_id = server->areas[current_area]->timers().indexOf(timer) + 1;
         if (timer->isActive()) {
             sendPacket("TI", {QString::number(timer_id), "2"});
@@ -204,7 +205,7 @@ void AOClient::arup(ARUPType type, bool broadcast)
 {
     QStringList arup_data;
     arup_data.append(QString::number(type));
-    for (AreaData* area : server->areas) {
+    for (AreaData* area : qAsConst(server->areas)) {
         switch(type) {
             case ARUPType::PLAYER_COUNT: {
                 arup_data.append(QString::number(area->playerCount()));
@@ -220,7 +221,8 @@ void AOClient::arup(ARUPType type, bool broadcast)
                     arup_data.append("FREE");
                 else {
                     QStringList area_owners;
-                    for (int owner_id : area->owners()) {
+                    const QList<int> owner_ids = area->owners();
+                    for (int owner_id : owner_ids) {
                         AOClient* owner = server->getClientByID(owner_id);
                         area_owners.append("[" + QString::number(owner->id) + "] " + owner->current_char);
                     }

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -102,6 +102,8 @@ void AOClient::cmdUnCM(int argc, QStringList argv)
 
 void AOClient::cmdInvite(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     bool ok;
     int invited_id = argv[0].toInt(&ok);
@@ -122,6 +124,8 @@ void AOClient::cmdInvite(int argc, QStringList argv)
 
 void AOClient::cmdUnInvite(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     bool ok;
     int uninvited_id = argv[0].toInt(&ok);
@@ -146,6 +150,9 @@ void AOClient::cmdUnInvite(int argc, QStringList argv)
 
 void AOClient::cmdLock(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->lockStatus() == AreaData::LockStatus::LOCKED) {
         sendServerMessage("This area is already locked.");
@@ -153,7 +160,7 @@ void AOClient::cmdLock(int argc, QStringList argv)
     }
     sendServerMessageArea("This area is now locked.");
     area->lock();
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) { // qAsConst here avoids detaching the container
         if (client->current_area == current_area && client->joined) {
             area->invite(client->id);
         }
@@ -163,6 +170,9 @@ void AOClient::cmdLock(int argc, QStringList argv)
 
 void AOClient::cmdSpectatable(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->lockStatus() == AreaData::LockStatus::SPECTATABLE) {
         sendServerMessage("This area is already in spectate mode.");
@@ -170,7 +180,7 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
     }
     sendServerMessageArea("This area is now spectatable.");
     area->spectatable();
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->current_area == current_area && client->joined) {
             area->invite(client->id);
         }
@@ -180,6 +190,9 @@ void AOClient::cmdSpectatable(int argc, QStringList argv)
 
 void AOClient::cmdUnLock(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->lockStatus() == AreaData::LockStatus::FREE) {
         sendServerMessage("This area is not locked.");
@@ -192,6 +205,9 @@ void AOClient::cmdUnLock(int argc, QStringList argv)
 
 void AOClient::cmdGetAreas(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList entries;
     entries.append("== Area List ==");
     for (int i = 0; i < server->area_names.length(); i++) {
@@ -203,12 +219,17 @@ void AOClient::cmdGetAreas(int argc, QStringList argv)
 
 void AOClient::cmdGetArea(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList entries = buildAreaList(current_area);
     sendServerMessage(entries.join("\n"));
 }
 
 void AOClient::cmdArea(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     int new_area = argv[0].toInt(&ok);
     if (!ok || new_area >= server->areas.size() || new_area < 0) {
@@ -220,6 +241,8 @@ void AOClient::cmdArea(int argc, QStringList argv)
 
 void AOClient::cmdAreaKick(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     int idx = argv[0].toInt(&ok);
     if (!ok) {
@@ -237,6 +260,8 @@ void AOClient::cmdAreaKick(int argc, QStringList argv)
 
 void AOClient::cmdSetBackground(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     if (authenticated || !area->bgLocked()) {
         if (server->backgrounds.contains(argv[0]) || area->ignoreBgList() == true) {
@@ -255,6 +280,9 @@ void AOClient::cmdSetBackground(int argc, QStringList argv)
 
 void AOClient::cmdBgLock(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
 
     if (area->bgLocked() == false) {
@@ -266,6 +294,9 @@ void AOClient::cmdBgLock(int argc, QStringList argv)
 
 void AOClient::cmdBgUnlock(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
 
     if (area->bgLocked() == true) {
@@ -277,6 +308,8 @@ void AOClient::cmdBgUnlock(int argc, QStringList argv)
 
 void AOClient::cmdStatus(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     QString arg = argv[0].toLower();
 
@@ -290,6 +323,9 @@ void AOClient::cmdStatus(int argc, QStringList argv)
 
 void AOClient::cmdJudgeLog(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->judgelog().isEmpty()) {
         sendServerMessage("There have been no judge actions in this area.");
@@ -308,6 +344,9 @@ void AOClient::cmdJudgeLog(int argc, QStringList argv)
 
 void AOClient::cmdIgnoreBgList(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     area->toggleIgnoreBgList();
     QString state = area->ignoreBgList() ? "ignored." : "enforced.";

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -336,7 +336,8 @@ void AOClient::cmdStatus(int argc, QStringList argv)
         arup(ARUPType::STATUS, true);
         server->broadcast(AOPacket("CT", {ConfigManager::serverName(), current_char + " changed status to " + arg.toUpper(), "1"}), current_area);
     } else {
-        sendServerMessage("That does not look like a valid status. Valid statuses are " + AreaData::map_statuses.keys().join(", "));
+        const QStringList keys = AreaData::map_statuses.keys();
+        sendServerMessage("That does not look like a valid status. Valid statuses are " + keys.join(", "));
     }
 }
 

--- a/core/src/commands/authentication.cpp
+++ b/core/src/commands/authentication.cpp
@@ -22,6 +22,9 @@
 
 void AOClient::cmdLogin(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (authenticated) {
         sendServerMessage("You are already logged in!");
         return;
@@ -48,6 +51,9 @@ void AOClient::cmdLogin(int argc, QStringList argv)
 
 void AOClient::cmdChangeAuth(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (ConfigManager::authType() == DataTypes::AuthType::SIMPLE) {
         change_auth_started = true;
         sendServerMessage("WARNING!\nThis command will change how logging in as a moderator works.\nOnly proceed if you know what you are doing\nUse the command /rootpass to set the password for your root account.");
@@ -56,6 +62,8 @@ void AOClient::cmdChangeAuth(int argc, QStringList argv)
 
 void AOClient::cmdSetRootPass(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     if (!change_auth_started)
         return;
 
@@ -83,6 +91,8 @@ void AOClient::cmdSetRootPass(int argc, QStringList argv)
 
 void AOClient::cmdAddUser(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     if (!checkPasswordRequirements(argv[0], argv[1])) {
         sendServerMessage("Password does not meet server requirements.");
         return;
@@ -105,6 +115,8 @@ void AOClient::cmdAddUser(int argc, QStringList argv)
 
 void AOClient::cmdRemoveUser(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     if (server->db_manager->deleteUser(argv[0]))
         sendServerMessage("Successfully removed user " + argv[0] + ".");
     else
@@ -153,6 +165,8 @@ void AOClient::cmdListPerms(int argc, QStringList argv)
 
 void AOClient::cmdAddPerms(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     unsigned long long user_acl = server->db_manager->getACL(moderator_name);
     argv[1] = argv[1].toUpper();
 
@@ -187,6 +201,8 @@ void AOClient::cmdAddPerms(int argc, QStringList argv)
 
 void AOClient::cmdRemovePerms(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     unsigned long long user_acl = server->db_manager->getACL(moderator_name);
     argv[1] = argv[1].toUpper();
 
@@ -226,12 +242,18 @@ void AOClient::cmdRemovePerms(int argc, QStringList argv)
 
 void AOClient::cmdListUsers(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList users = server->db_manager->getUsers();
     sendServerMessage("All users:\n" + users.join("\n"));
 }
 
 void AOClient::cmdLogout(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (!authenticated) {
         sendServerMessage("You are not logged in!");
         return;

--- a/core/src/commands/authentication.cpp
+++ b/core/src/commands/authentication.cpp
@@ -127,10 +127,11 @@ void AOClient::cmdListPerms(int argc, QStringList argv)
 {
     unsigned long long user_acl = server->db_manager->getACL(moderator_name);
     QStringList message;
+    const QStringList keys = ACLFlags.keys();
     if (argc == 0) {
         // Just print out all permissions available to the user.
         message.append("You have been given the following permissions:");
-        for (QString perm : ACLFlags.keys()) {
+        for (const QString &perm : keys) {
             if (perm == "NONE"); // don't need to list this one
             else if (perm == "SUPER") {
                 if (user_acl == ACLFlags.value("SUPER")) // This has to be checked separately, because SUPER & anything will always be truthy
@@ -154,7 +155,7 @@ void AOClient::cmdListPerms(int argc, QStringList argv)
             return;
         }
 
-        for (QString perm : ACLFlags.keys()) {
+        for (const QString &perm : keys) {
             if ((ACLFlags.value(perm) & acl) != 0 && perm != "SUPER") {
                 message.append(perm);
             }
@@ -169,8 +170,9 @@ void AOClient::cmdAddPerms(int argc, QStringList argv)
 
     unsigned long long user_acl = server->db_manager->getACL(moderator_name);
     argv[1] = argv[1].toUpper();
+    const QStringList keys = ACLFlags.keys();
 
-    if (!ACLFlags.keys().contains(argv[1])) {
+    if (!keys.contains(argv[1])) {
         sendServerMessage("That permission doesn't exist!");
         return;
     }
@@ -206,7 +208,9 @@ void AOClient::cmdRemovePerms(int argc, QStringList argv)
     unsigned long long user_acl = server->db_manager->getACL(moderator_name);
     argv[1] = argv[1].toUpper();
 
-    if (!ACLFlags.keys().contains(argv[1])) {
+    const QStringList keys = ACLFlags.keys();
+
+    if (!keys.contains(argv[1])) {
         sendServerMessage("That permission doesn't exist!");
         return;
     }

--- a/core/src/commands/casing.cpp
+++ b/core/src/commands/casing.cpp
@@ -35,6 +35,9 @@ void AOClient::cmdDoc(int argc, QStringList argv)
 
 void AOClient::cmdClearDoc(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QString sender_name = ooc_name;
     AreaData* area = server->areas[current_area];
     area->changeDoc("No document.");
@@ -43,6 +46,8 @@ void AOClient::cmdClearDoc(int argc, QStringList argv)
 
 void AOClient::cmdEvidenceMod(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     argv[0] = argv[0].toLower();
     if (argv[0] == "cm")
@@ -65,6 +70,8 @@ void AOClient::cmdEvidenceMod(int argc, QStringList argv)
 
 void AOClient::cmdEvidence_Swap(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     int ev_size = area->evidence().size() -1;
 
@@ -96,6 +103,9 @@ void AOClient::cmdEvidence_Swap(int argc, QStringList argv)
 
 void AOClient::cmdTestify(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING) {
         sendServerMessage("Testimony recording is already in progress. Please stop it before starting a new one.");
@@ -109,6 +119,9 @@ void AOClient::cmdTestify(int argc, QStringList argv)
 
 void AOClient::cmdExamine(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->testimony().size() -1 > 0)
     {
@@ -125,6 +138,9 @@ void AOClient::cmdExamine(int argc, QStringList argv)
 
 void AOClient::cmdTestimony(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
    AreaData* area = server->areas[current_area];
    if (area->testimony().size() -1 < 1) {
        sendServerMessage("Unable to display empty testimony.");
@@ -143,6 +159,9 @@ void AOClient::cmdTestimony(int argc, QStringList argv)
 
 void AOClient::cmdDeleteStatement(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     int c_statement = area->statement();
     if (area->testimony().size() - 1 == 0) {
@@ -156,12 +175,18 @@ void AOClient::cmdDeleteStatement(int argc, QStringList argv)
 
 void AOClient::cmdUpdateStatement(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     server->areas[current_area]->setTestimonyRecording(AreaData::TestimonyRecording::UPDATE);
     sendServerMessage("The next IC-Message will replace the last displayed replay message.");
 }
 
 void AOClient::cmdPauseTestimony(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     area->setTestimonyRecording(AreaData::TestimonyRecording::STOPPED);
     server->broadcast(AOPacket("RT",{"testimony1", "1"}), current_area);
@@ -170,6 +195,9 @@ void AOClient::cmdPauseTestimony(int argc, QStringList argv)
 
 void AOClient::cmdAddStatement(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (server->areas[current_area]->statement() < ConfigManager::maxStatements()) {
         server->areas[current_area]->setTestimonyRecording(AreaData::TestimonyRecording::ADD);
         sendServerMessage("The next IC-Message will be inserted into the testimony.");
@@ -180,6 +208,8 @@ void AOClient::cmdAddStatement(int argc, QStringList argv)
 
 void AOClient::cmdSaveTestimony(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool permission_found = false;
     if (checkAuth(ACLFlags.value("SAVETEST")))
         permission_found = true;
@@ -225,6 +255,8 @@ void AOClient::cmdSaveTestimony(int argc, QStringList argv)
 
 void AOClient::cmdLoadTestimony(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     QDir dir_testimony("storage/testimony");
     if (!dir_testimony.exists()) {

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -22,6 +22,9 @@
 
 void AOClient::cmdDefault(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     sendServerMessage("Invalid command.");
     return;
 }

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -47,7 +47,7 @@ QStringList AOClient::buildAreaList(int area_idx)
             break;
     }
     entries.append("[" + QString::number(area->playerCount()) + " users][" + QVariant::fromValue(area->status()).toString().replace("_", "-") + "]");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->current_area == area_idx && client->joined) {
             QString char_entry = "[" + QString::number(client->id) + "] " + client->current_char;
             if (client->current_char == "")
@@ -168,10 +168,10 @@ long long AOClient::parseTime(QString input)
 QString AOClient::getReprimand(bool positive)
 {
     if (positive) {
-        return ConfigManager::praiseList()[genRand(0, ConfigManager::praiseList().size() - 1)];
+        return ConfigManager::praiseList().at(genRand(0, ConfigManager::praiseList().size() - 1));
         }
     else {
-        return ConfigManager::reprimandsList()[genRand(0, ConfigManager::reprimandsList().size() - 1)];
+        return ConfigManager::reprimandsList().at(genRand(0, ConfigManager::reprimandsList().size() - 1));
         }
 }
 

--- a/core/src/commands/messaging.cpp
+++ b/core/src/commands/messaging.cpp
@@ -22,15 +22,18 @@
 
 void AOClient::cmdPos(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     changePosition(argv[0]);
     updateEvidenceList(server->areas[current_area]);
 }
 
 void AOClient::cmdForcePos(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     QList<AOClient*> targets;
-    AreaData* area = server->areas[current_area];
     int target_id = argv[1].toInt(&ok);
     int forced_clients = 0;
     if (!ok && argv[1] != "*") {
@@ -48,7 +51,7 @@ void AOClient::cmdForcePos(int argc, QStringList argv)
     }
 
     else if (argv[1] == "*") { // force all clients in the area
-        for (AOClient* client : server->clients) {
+        for (AOClient* client : qAsConst(server->clients)) {
             if (client->current_area == current_area)
                 targets.append(client);
         }
@@ -63,10 +66,12 @@ void AOClient::cmdForcePos(int argc, QStringList argv)
 
 void AOClient::cmdG(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString sender_name = ooc_name;
     QString sender_area = server->area_names.value(current_area);
     QString sender_message = argv.join(" ");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->global_enabled)
             client->sendPacket("CT", {"[G][" + sender_area + "]" + sender_name, sender_message});
     }
@@ -75,9 +80,11 @@ void AOClient::cmdG(int argc, QStringList argv)
 
 void AOClient::cmdNeed(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString sender_area = server->area_names.value(current_area);
     QString sender_message = argv.join(" ");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->advert_enabled) {
             client->sendServerMessage({"=== Advert ===\n[" + sender_area + "] needs " + sender_message+ "."});
         }
@@ -86,6 +93,8 @@ void AOClient::cmdNeed(int argc, QStringList argv)
 
 void AOClient::cmdSwitch(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     int selected_char_id = server->getCharID(argv.join(" "));
     if (selected_char_id == -1) {
         sendServerMessage("That does not look like a valid character.");
@@ -101,6 +110,9 @@ void AOClient::cmdSwitch(int argc, QStringList argv)
 
 void AOClient::cmdRandomChar(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     int selected_char_id;
     bool taken = true;
@@ -117,13 +129,18 @@ void AOClient::cmdRandomChar(int argc, QStringList argv)
 
 void AOClient::cmdToggleGlobal(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     global_enabled = !global_enabled;
     QString str_en = global_enabled ? "shown" : "hidden";
     sendServerMessage("Global chat set to " + str_en);
 }
 
-void AOClient::cmdPM(int arc, QStringList argv)
+void AOClient::cmdPM(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     int target_id = argv.takeFirst().toInt(&ok); // using takeFirst removes the ID from our list of arguments...
     if (!ok) {
@@ -145,14 +162,18 @@ void AOClient::cmdPM(int arc, QStringList argv)
 
 void AOClient::cmdAnnounce(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     sendServerBroadcast("=== Announcement ===\r\n" + argv.join(" ") + "\r\n=============");
 }
 
 void AOClient::cmdM(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString sender_name = ooc_name;
     QString sender_message = argv.join(" ");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->checkAuth(ACLFlags.value("MODCHAT")))
             client->sendPacket("CT", {"[M]" + sender_name, sender_message});
     }
@@ -161,10 +182,12 @@ void AOClient::cmdM(int argc, QStringList argv)
 
 void AOClient::cmdGM(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString sender_name = ooc_name;
     QString sender_area = server->area_names.value(current_area);
     QString sender_message = argv.join(" ");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->global_enabled) {
             client->sendPacket("CT", {"[G][" + sender_area + "]" + "["+sender_name+"][M]", sender_message});
         }
@@ -173,6 +196,8 @@ void AOClient::cmdGM(int argc, QStringList argv)
 
 void AOClient::cmdLM(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString sender_name = ooc_name;
     QString sender_message = argv.join(" ");
     server->broadcast(AOPacket("CT", {"["+sender_name+"][M]", sender_message}), current_area);
@@ -180,6 +205,8 @@ void AOClient::cmdLM(int argc, QStringList argv)
 
 void AOClient::cmdGimp(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -205,6 +232,8 @@ void AOClient::cmdGimp(int argc, QStringList argv)
 
 void AOClient::cmdUnGimp(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -230,6 +259,8 @@ void AOClient::cmdUnGimp(int argc, QStringList argv)
 
 void AOClient::cmdDisemvowel(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -255,6 +286,8 @@ void AOClient::cmdDisemvowel(int argc, QStringList argv)
 
 void AOClient::cmdUnDisemvowel(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -280,6 +313,8 @@ void AOClient::cmdUnDisemvowel(int argc, QStringList argv)
 
 void AOClient::cmdShake(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -305,6 +340,8 @@ void AOClient::cmdShake(int argc, QStringList argv)
 
 void AOClient::cmdUnShake(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -330,6 +367,9 @@ void AOClient::cmdUnShake(int argc, QStringList argv)
 
 void AOClient::cmdMutePM(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     pm_mute = !pm_mute;
     QString str_en = pm_mute ? "muted" : "unmuted";
     sendServerMessage("PM's are now " + str_en);
@@ -337,6 +377,9 @@ void AOClient::cmdMutePM(int argc, QStringList argv)
 
 void AOClient::cmdToggleAdverts(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     advert_enabled = !advert_enabled;
     QString str_en = advert_enabled ? "on" : "off";
     sendServerMessage("Advertisements turned " + str_en);
@@ -344,6 +387,9 @@ void AOClient::cmdToggleAdverts(int argc, QStringList argv)
 
 void AOClient::cmdAfk(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     is_afk = true;
     sendServerMessage("You are now AFK.");
 }
@@ -377,7 +423,7 @@ void AOClient::cmdCharCurse(int argc, QStringList argv)
         QStringList char_names = argv.join(" ").split(",");
 
         target->charcurse_list.clear();
-        for (QString char_name : char_names) {
+        for (const QString &char_name : qAsConst(char_names)) {
             int char_id = server->getCharID(char_name);
             if (char_id == -1) {
                 sendServerMessage("Could not find character: " + char_name);
@@ -405,6 +451,8 @@ void AOClient::cmdCharCurse(int argc, QStringList argv)
 
 void AOClient::cmdUnCharCurse(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -459,6 +507,8 @@ void AOClient::cmdCharSelect(int argc, QStringList argv)
 
 void AOClient::cmdA(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     int area_id = argv[0].toInt(&ok);
     if (!ok) {
@@ -480,6 +530,8 @@ void AOClient::cmdA(int argc, QStringList argv)
 
 void AOClient::cmdS(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     int all_areas = server->areas.size() - 1;
     QString sender_name = ooc_name;
     QString ooc_message = argv.join(" ");
@@ -492,6 +544,9 @@ void AOClient::cmdS(int argc, QStringList argv)
 
 void AOClient::cmdFirstPerson(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     first_person = !first_person;
     QString str_en = first_person ? "enabled" : "disabled";
     sendServerMessage("First person mode " + str_en + ".");

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -559,9 +559,13 @@ void AOClient::cmdUpdateBan(int argc, QStringList argv)
 
 void AOClient::cmdNotice(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     sendNotice(argv.join(" "));
 }
 void AOClient::cmdNoticeGlobal(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     sendNotice(argv.join(" "), true);
 }

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -113,9 +113,12 @@ void AOClient::cmdKick(int argc, QStringList argv)
 
 void AOClient::cmdMods(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList entries;
     int online_count = 0;
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->authenticated) {
             entries << "---";
             if (ConfigManager::authType() != DataTypes::AuthType::SIMPLE)
@@ -134,6 +137,9 @@ void AOClient::cmdMods(int argc, QStringList argv)
 
 void AOClient::cmdHelp(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList entries;
     entries << "Allowed commands:";
     QMap<QString, CommandInfo>::const_iterator i;
@@ -165,6 +171,9 @@ void AOClient::cmdMOTD(int argc, QStringList argv)
 
 void AOClient::cmdBans(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QStringList recent_bans;
     recent_bans << "Last 5 bans:";
     recent_bans << "-----";
@@ -188,6 +197,8 @@ void AOClient::cmdBans(int argc, QStringList argv)
 
 void AOClient::cmdUnBan(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool ok;
     int target_ban = argv[0].toInt(&ok);
     if (!ok) {
@@ -202,11 +213,16 @@ void AOClient::cmdUnBan(int argc, QStringList argv)
 
 void AOClient::cmdAbout(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     sendPacket("CT", {"The akashi dev team", "Thank you for using akashi! Made with love by scatterflower, with help from in1tiate, Salanto, and mangosarentliterature. akashi " + QCoreApplication::applicationVersion() + ". For documentation and reporting issues, see the source: https://github.com/AttorneyOnline/akashi"});
 }
 
 void AOClient::cmdMute(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -232,6 +248,8 @@ void AOClient::cmdMute(int argc, QStringList argv)
 
 void AOClient::cmdUnMute(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -257,6 +275,8 @@ void AOClient::cmdUnMute(int argc, QStringList argv)
 
 void AOClient::cmdOocMute(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -282,6 +302,8 @@ void AOClient::cmdOocMute(int argc, QStringList argv)
 
 void AOClient::cmdOocUnMute(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -307,6 +329,8 @@ void AOClient::cmdOocUnMute(int argc, QStringList argv)
 
 void AOClient::cmdBlockWtce(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -332,6 +356,8 @@ void AOClient::cmdBlockWtce(int argc, QStringList argv)
 
 void AOClient::cmdUnBlockWtce(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -357,6 +383,9 @@ void AOClient::cmdUnBlockWtce(int argc, QStringList argv)
 
 void AOClient::cmdAllowBlankposting(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QString sender_name = ooc_name;
     AreaData* area = server->areas[current_area];
     area->toggleBlankposting();
@@ -390,7 +419,8 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
         return;
     }
     QString id = argv[0];
-    for (DBManager::BanInfo ban : server->db_manager->getBanInfo(lookup_type, id)) {
+    const QList<DBManager::BanInfo> bans = server->db_manager->getBanInfo(lookup_type, id);
+    for (const DBManager::BanInfo &ban : bans) {
         QString banned_until;
         if (ban.duration == -2)
             banned_until = "The heat death of the universe";
@@ -410,6 +440,9 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
 
 void AOClient::cmdReload(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     ConfigManager::reloadSettings();
     emit server->reloadRequest(ConfigManager::serverName(), ConfigManager::serverDescription());
     server->reloadHTTPAdvertiserConfig();
@@ -418,6 +451,9 @@ void AOClient::cmdReload(int argc, QStringList argv)
 
 void AOClient::cmdForceImmediate(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     area->toggleImmediate();
     QString state = area->forceImmediate() ? "on." : "off.";
@@ -426,6 +462,9 @@ void AOClient::cmdForceImmediate(int argc, QStringList argv)
 
 void AOClient::cmdAllowIniswap(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     area->toggleIniswap();
     QString state = area->iniswapAllowed() ? "allowed." : "disallowed.";
@@ -434,6 +473,8 @@ void AOClient::cmdAllowIniswap(int argc, QStringList argv)
 
 void AOClient::cmdPermitSaving(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AOClient* client = server->getClientByID(argv[0].toInt());
     if (client == nullptr) {
         sendServerMessage("Invalid ID.");

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -57,7 +57,8 @@ void AOClient::cmdBan(int argc, QStringList argv)
         break;
     }
 
-    for (AOClient* client : server->getClientsByIpid(ban.ipid)) {
+    const QList<AOClient*> targets = server->getClientsByIpid(ban.ipid);
+    for (AOClient* client : targets) {
         if (!ban_logged) {
             ban.ip = client->remote_ip;
             ban.hdid = client->hwid;
@@ -103,7 +104,8 @@ void AOClient::cmdKick(int argc, QStringList argv)
         }
     }
 
-    for (AOClient* client : server->getClientsByIpid(target_ipid)) {
+    const QList<AOClient*> targets = server->getClientsByIpid(target_ipid);
+    for (AOClient* client : targets) {
         client->sendPacket("KK", {reason});
         client->socket->close();
         kick_counter++;
@@ -181,7 +183,8 @@ void AOClient::cmdBans(int argc, QStringList argv)
     QStringList recent_bans;
     recent_bans << "Last 5 bans:";
     recent_bans << "-----";
-    for (DBManager::BanInfo ban : server->db_manager->getRecentBans()) {
+    const QList<DBManager::BanInfo> bans_list = server->db_manager->getRecentBans();
+    for (const DBManager::BanInfo &ban : bans_list) {
         QString banned_until;
         if (ban.duration == -2)
             banned_until = "The heat death of the universe";

--- a/core/src/commands/music.cpp
+++ b/core/src/commands/music.cpp
@@ -22,6 +22,8 @@
 
 void AOClient::cmdPlay(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     if (is_dj_blocked) {
         sendServerMessage("You are blocked from changing the music.");
         return;
@@ -36,6 +38,9 @@ void AOClient::cmdPlay(int argc, QStringList argv)
 
 void AOClient::cmdCurrentMusic(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (area->currentMusic() != "" && area->currentMusic() != "~stop.mp3") // dummy track for stopping music
         sendServerMessage("The current song is " + area->currentMusic() + " played by " + area->musicPlayerBy());
@@ -45,6 +50,8 @@ void AOClient::cmdCurrentMusic(int argc, QStringList argv)
 
 void AOClient::cmdBlockDj(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -70,6 +77,8 @@ void AOClient::cmdBlockDj(int argc, QStringList argv)
 
 void AOClient::cmdUnBlockDj(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     bool conv_ok = false;
     int uid = argv[0].toInt(&conv_ok);
     if (!conv_ok) {
@@ -95,6 +104,9 @@ void AOClient::cmdUnBlockDj(int argc, QStringList argv)
 
 void AOClient::cmdToggleMusic(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     area->toggleMusic();
     QString state = area->isMusicAllowed() ? "allowed." : "disallowed.";

--- a/core/src/commands/roleplay.cpp
+++ b/core/src/commands/roleplay.cpp
@@ -22,6 +22,9 @@
 
 void AOClient::cmdFlip(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     QString sender_name = ooc_name;
     QStringList faces = {"heads","tails"};
     QString face = faces[AOClient::genRand(0,1)];
@@ -129,6 +132,8 @@ void AOClient::cmdTimer(int argc, QStringList argv)
 
 void AOClient::cmdNoteCard(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     AreaData* area = server->areas[current_area];
     QString notecard = argv.join(" ");
     area->addNotecard(current_char, notecard);
@@ -137,6 +142,9 @@ void AOClient::cmdNoteCard(int argc, QStringList argv)
 
 void AOClient::cmdNoteCardClear(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     if (!area->addNotecard(current_char, QString())) {
         sendServerMessageArea(current_char + " erased their note card.");
@@ -145,6 +153,9 @@ void AOClient::cmdNoteCardClear(int argc, QStringList argv)
 
 void AOClient::cmdNoteCardReveal(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     AreaData* area = server->areas[current_area];
     const QStringList l_notecards = area->getNotecards();
 
@@ -161,12 +172,14 @@ void AOClient::cmdNoteCardReveal(int argc, QStringList argv)
 
 void AOClient::cmd8Ball(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     if (ConfigManager::magic8BallAnswers().isEmpty()) {
         qWarning() << "8ball.txt is empty!";
         sendServerMessage("8ball.txt is empty.");
         }
     else {
-        QString response = ConfigManager::magic8BallAnswers()[(genRand(1, ConfigManager::magic8BallAnswers().size() - 1))];
+        QString response = ConfigManager::magic8BallAnswers().at((genRand(1, ConfigManager::magic8BallAnswers().size() - 1)));
         QString sender_name = ooc_name;
         QString sender_message = argv.join(" ");
 
@@ -176,8 +189,10 @@ void AOClient::cmd8Ball(int argc, QStringList argv)
 
 void AOClient::cmdSubTheme(int argc, QStringList argv)
 {
+    Q_UNUSED(argc);
+
     QString subtheme = argv.join(" ");
-    for (AOClient* client : server->clients) {
+    for (AOClient* client : qAsConst(server->clients)) {
         if (client->current_area == current_area)
             client->sendPacket("ST", {subtheme, "1"});
     }

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -24,7 +24,7 @@ bool ConfigManager::verifyServerConfig()
 {
     // Verify directories
     QStringList l_directories{"config/", "config/text/"};
-    for (QString l_directory : l_directories) {
+    for (const QString &l_directory : l_directories) {
         if (!dirExists(QFileInfo(l_directory))) {
                 qCritical() << l_directory + " does not exist!";
                 return false;
@@ -34,7 +34,7 @@ bool ConfigManager::verifyServerConfig()
     // Verify config files
     QStringList l_config_files{"config/config.ini", "config/areas.ini", "config/backgrounds.txt", "config/characters.txt", "config/music.txt",
                               "config/text/8ball.txt", "config/text/gimp.txt", "config/text/praise.txt", "config/text/reprimands.txt"};
-    for (QString l_file : l_config_files) {
+    for (const QString &l_file : l_config_files) {
         if (!fileExists(QFileInfo(l_file))) {
             qCritical() << l_file + " does not exist!";
             return false;

--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -26,7 +26,9 @@ DBManager::DBManager() :
         qCritical() << "Database Error:" << db.lastError();
     db_version = checkVersion();
     QSqlQuery create_ban_table("CREATE TABLE IF NOT EXISTS bans ('ID' INTEGER, 'IPID' TEXT, 'HDID' TEXT, 'IP' TEXT, 'TIME' INTEGER, 'REASON' TEXT, 'DURATION' INTEGER, 'MODERATOR' TEXT, PRIMARY KEY('ID' AUTOINCREMENT))");
+    create_ban_table.exec();
     QSqlQuery create_user_table("CREATE TABLE IF NOT EXISTS users ('ID' INTEGER, 'USERNAME' TEXT, 'SALT' TEXT, 'PASSWORD' TEXT, 'ACL' TEXT, PRIMARY KEY('ID' AUTOINCREMENT))");
+    create_user_table.exec();
     if (db_version != DB_VERSION)
         updateDB(db_version);
 }
@@ -380,6 +382,7 @@ void DBManager::updateDB(int current_version)
     switch (current_version) {
     case 0:
         QSqlQuery("ALTER TABLE bans ADD COLUMN MODERATOR TEXT");
+        Q_FALLTHROUGH();
     case 1:
         QSqlQuery ("PRAGMA user_version = " + QString::number(DB_VERSION));
         break;

--- a/core/src/discord.cpp
+++ b/core/src/discord.cpp
@@ -63,7 +63,7 @@ QHttpMultiPart* Discord::constructLogMultipart(const QQueue<QString> &f_buffer) 
     l_file.setRawHeader(QByteArray("Content-Disposition"), QByteArray("form-data; name=\"file\"; filename=\"log.txt\""));
     l_file.setRawHeader(QByteArray("Content-Type"), QByteArray("plain/text"));
     QString l_log;
-    for (QString log_entry : f_buffer) {
+    for (const QString &log_entry : f_buffer) {
         l_log.append(log_entry + "\n");
     }
     l_file.setBody(l_log.toUtf8());
@@ -99,6 +99,8 @@ void Discord::onReplyFinished(QNetworkReply *f_reply)
     f_reply->deleteLater();
 #ifdef DISCORD_DEBUG
     QDebug() << l_data;
+#else
+    Q_UNUSED(l_data);
 #endif
 }
 

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -19,13 +19,22 @@
 
 void AOClient::pktDefault(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
 #ifdef NET_DEBUG
     qDebug() << "Unimplemented packet:" << packet.header << packet.contents;
+#else
+    Q_UNUSED(packet);
 #endif
 }
 
 void AOClient::pktHardwareId(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     hwid = argv[0];
     auto ban = server->db_manager->isHDIDBanned(hwid);
     if (ban.first) {
@@ -38,7 +47,9 @@ void AOClient::pktHardwareId(AreaData* area, int argc, QStringList argv, AOPacke
 
 void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
-
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
 
     // Full feature list as of AO 2.8.5
     // The only ones that are critical to ensuring the server works are
@@ -73,6 +84,11 @@ void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacke
 
 void AOClient::pktBeginLoad(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    Q_UNUSED(packet);
+
     // Evidence isn't loaded during this part anymore
     // As a result, we can always send "0" for evidence length
     // Client only cares about what it gets from LE
@@ -81,16 +97,30 @@ void AOClient::pktBeginLoad(AreaData* area, int argc, QStringList argv, AOPacket
 
 void AOClient::pktRequestChars(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    Q_UNUSED(packet);
+
     sendPacket("SC", server->characters);
 }
 
 void AOClient::pktRequestMusic(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    Q_UNUSED(packet);
+
     sendPacket("SM", server->area_names + server->music_list);
 }
 
 void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    Q_UNUSED(packet);
+
     if (hwid == "") {
         // No early connecting!
         socket->close();
@@ -126,7 +156,8 @@ void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPack
     else {
         sendPacket("TI", {"0", "3"});
     }
-    for (QTimer* timer : area->timers()) {
+    const QList<QTimer*> timers = area->timers();
+    for (QTimer* timer : timers) {
         int timer_id = area->timers().indexOf(timer) + 1;
         if (timer->isActive()) {
             sendPacket("TI", {QString::number(timer_id), "2"});
@@ -140,11 +171,19 @@ void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPack
 
 void AOClient::pktCharPassword(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     password = argv[0];
 }
 
 void AOClient::pktSelectChar(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     bool argument_ok;
     int selected_char_id = argv[1].toInt(&argument_ok);
     if (!argument_ok) {
@@ -158,6 +197,9 @@ void AOClient::pktSelectChar(AreaData* area, int argc, QStringList argv, AOPacke
 
 void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (is_muted) {
         sendServerMessage("You cannot speak while muted.");
         return;
@@ -184,6 +226,9 @@ void AOClient::pktIcChat(AreaData* area, int argc, QStringList argv, AOPacket pa
 
 void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     if (is_ooc_muted) {
         sendServerMessage("You are OOC muted, and cannot speak.");
         return;
@@ -226,6 +271,11 @@ void AOClient::pktOocChat(AreaData* area, int argc, QStringList argv, AOPacket p
 
 void AOClient::pktPing(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+    Q_UNUSED(packet);
+
     // Why does this packet exist
     // At least Crystal made it useful
     // It is now used for ping measurement
@@ -234,6 +284,8 @@ void AOClient::pktPing(AreaData* area, int argc, QStringList argv, AOPacket pack
 
 void AOClient::pktChangeMusic(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(packet);
+
     // Due to historical reasons, this
     // packet has two functions:
     // Change area, and set music.
@@ -282,6 +334,9 @@ void AOClient::pktChangeMusic(AreaData* area, int argc, QStringList argv, AOPack
 
 void AOClient::pktWtCe(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     if (is_wtce_blocked) {
         sendServerMessage("You are blocked from using the judge controls.");
         return;
@@ -295,6 +350,9 @@ void AOClient::pktWtCe(AreaData* area, int argc, QStringList argv, AOPacket pack
 
 void AOClient::pktHpBar(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     if (is_wtce_blocked) {
         sendServerMessage("You are blocked from using the judge controls.");
         return;
@@ -316,6 +374,10 @@ void AOClient::pktHpBar(AreaData* area, int argc, QStringList argv, AOPacket pac
 
 void AOClient::pktWebSocketIp(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     // Special packet to set remote IP from the webao proxy
     // Only valid if from a local ip
     if (remote_ip.isLoopback()) {
@@ -346,6 +408,9 @@ void AOClient::pktWebSocketIp(AreaData* area, int argc, QStringList argv, AOPack
 
 void AOClient::pktModCall(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
     for (AOClient* client : server->clients) {
         if (client->authenticated)
             client->sendPacket(packet);
@@ -365,6 +430,9 @@ void AOClient::pktModCall(AreaData* area, int argc, QStringList argv, AOPacket p
 
 void AOClient::pktAddEvidence(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     if (!checkEvidenceAccess(area))
         return;
     AreaData::Evidence evi = {argv[0], argv[1], argv[2]};
@@ -374,6 +442,9 @@ void AOClient::pktAddEvidence(AreaData* area, int argc, QStringList argv, AOPack
 
 void AOClient::pktRemoveEvidence(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     if (!checkEvidenceAccess(area))
         return;
     bool is_int = false;
@@ -386,6 +457,9 @@ void AOClient::pktRemoveEvidence(AreaData* area, int argc, QStringList argv, AOP
 
 void AOClient::pktEditEvidence(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     if (!checkEvidenceAccess(area))
         return;
     bool is_int = false;
@@ -399,6 +473,10 @@ void AOClient::pktEditEvidence(AreaData* area, int argc, QStringList argv, AOPac
 
 void AOClient::pktSetCase(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     QList<bool> prefs_list;
     for (int i = 2; i <=6; i++) {
         bool is_int = false;
@@ -412,6 +490,10 @@ void AOClient::pktSetCase(AreaData* area, int argc, QStringList argv, AOPacket p
 
 void AOClient::pktAnnounceCase(AreaData* area, int argc, QStringList argv, AOPacket packet)
 {
+    Q_UNUSED(area);
+    Q_UNUSED(argc);
+    Q_UNUSED(packet);
+
     QString case_title = argv[0];
     QStringList needed_roles;
     QList<bool> needs_list;
@@ -434,9 +516,18 @@ void AOClient::pktAnnounceCase(AreaData* area, int argc, QStringList argv, AOPac
 
     QList<AOClient*> clients_to_alert;
     // here lies morton, RIP
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QSet<bool> needs_set(needs_list.begin(), needs_list.end());
+#else
     QSet<bool> needs_set = needs_list.toSet();
-    for (AOClient* client : server->clients) {
+#endif
+    for (AOClient* client : qAsConst(server->clients)) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QSet<bool> matches(client->casing_preferences.begin(), client->casing_preferences.end());
+        matches.intersect(needs_set);
+#else
         QSet<bool> matches = client->casing_preferences.toSet().intersect(needs_set);
+#endif
         if (!matches.isEmpty() && !clients_to_alert.contains(client))
             clients_to_alert.append(client);
     }
@@ -825,10 +916,12 @@ AOPacket AOClient::validateIcPacket(AOPacket packet)
             case AreaData::TestimonyProgress::LOOPED:
             {
                 sendServerMessageArea("Last statement reached. Looping to first statement.");
+                break;
             }
             case AreaData::TestimonyProgress::STAYED_AT_FIRST:
             {
                 sendServerMessage("First statement reached.");
+                Q_FALLTHROUGH();
             }
             case AreaData::TestimonyProgress::OK:
             default:

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -101,7 +101,7 @@ void Server::start()
     std::sort(area_names.begin(), area_names.end(), [] (const QString &a, const QString &b) {return a.split(":")[0].toInt() < b.split(":")[0].toInt();});
     QStringList sanitized_area_names;
     QStringList raw_area_names = area_names;
-    for (QString area_name : area_names) {
+    for (const QString &area_name : qAsConst(area_names)) {
         QStringList name_split = area_name.split(":");
         name_split.removeFirst();
         QString area_name_sanitized = name_split.join(":");
@@ -120,7 +120,7 @@ void Server::clientConnected()
     QTcpSocket* socket = server->nextPendingConnection();
     int user_id;
     QList<int> user_ids;
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         user_ids.append(client->id);
     }
     for (user_id = 0; user_id <= player_count; user_id++) {
@@ -136,7 +136,7 @@ void Server::clientConnected()
     client->calculateIpid();
     auto ban = db_manager->isIPBanned(client->getIpid());
     bool is_banned = ban.first;
-    for (AOClient* joined_client : clients) {
+    for (AOClient* joined_client : qAsConst(clients)) {
         if (client->remote_ip.isEqual(joined_client->remote_ip))
             multiclient_count++;
     }
@@ -177,7 +177,7 @@ void Server::clientConnected()
 void Server::updateCharsTaken(AreaData* area)
 {
     QStringList chars_taken;
-    for (QString cur_char : characters) {
+    for (const QString &cur_char : qAsConst(characters)) {
         chars_taken.append(area->charactersTaken().contains(getCharID(cur_char))
                                ? QStringLiteral("-1")
                                : QStringLiteral("0"));
@@ -185,7 +185,7 @@ void Server::updateCharsTaken(AreaData* area)
 
     AOPacket response_cc("CharsCheck", chars_taken);
 
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         if (client->current_area == area->index()){
             if (!client->is_charcursed)
                 client->sendPacket(response_cc);
@@ -212,7 +212,7 @@ QStringList Server::getCursedCharsTaken(AOClient* client, QStringList chars_take
 
 void Server::broadcast(AOPacket packet, int area_index)
 {
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         if (client->current_area == area_index)
             client->sendPacket(packet);
     }
@@ -220,7 +220,7 @@ void Server::broadcast(AOPacket packet, int area_index)
 
 void Server::broadcast(AOPacket packet)
 {
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         client->sendPacket(packet);
     }
 }
@@ -228,7 +228,7 @@ void Server::broadcast(AOPacket packet)
 QList<AOClient*> Server::getClientsByIpid(QString ipid)
 {
     QList<AOClient*> return_clients;
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         if (client->getIpid() == ipid)
             return_clients.append(client);
     }
@@ -237,7 +237,7 @@ QList<AOClient*> Server::getClientsByIpid(QString ipid)
 
 AOClient* Server::getClientByID(int id)
 {
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         if (client->id == id)
             return client;
     }
@@ -246,7 +246,7 @@ AOClient* Server::getClientByID(int id)
 
 int Server::getCharID(QString char_name)
 {
-    for (QString character : characters) {
+    for (const QString &character : qAsConst(characters)) {
         if (character.toLower() == char_name.toLower()) {
             return characters.indexOf(QRegExp(character, Qt::CaseInsensitive));
         }
@@ -308,7 +308,7 @@ void Server::handleDiscordIntegration()
 
 Server::~Server()
 {
-    for (AOClient* client : clients) {
+    for (AOClient* client : qAsConst(clients)) {
         client->deleteLater();
     }
     server->deleteLater();

--- a/core/src/ws_client.cpp
+++ b/core/src/ws_client.cpp
@@ -43,7 +43,7 @@ void WSClient::onTcpData()
     // Workaround for WebAO bug needing every packet in its own message
     QStringList all_packets = QString::fromUtf8(tcp_message).split("%");
     all_packets.removeLast(); // Remove empty space after final delimiter
-    for(QString packet : all_packets) {
+    for(const QString &packet : qAsConst(all_packets)) {
         web_socket->sendTextMessage(packet + "%");
     }
 }

--- a/core/src/ws_proxy.cpp
+++ b/core/src/ws_proxy.cpp
@@ -22,7 +22,7 @@ WSProxy::WSProxy(int p_local_port, int p_ws_port, QObject* parent) :
     local_port(p_local_port),
     ws_port(p_ws_port)
 {
-    server = new QWebSocketServer(QStringLiteral(""),
+    server = new QWebSocketServer(QLatin1String(""),
                                   QWebSocketServer::NonSecureMode, this);
     connect(server, &QWebSocketServer::newConnection, this,
             &WSProxy::wsConnected);


### PR DESCRIPTION
- Used macro `Q_UNUSED()` to suppress "unused argument" warnings
- Corrected the order of `Logger`'s constructor arguments to fix "will be initialized before" warnings
- Liberal use of `const` and `qAsConst()` in range-for loops to fix "missing reference in range-for with non trivial type" and "c++11 range loop might detach Qt container" warnings
- Explicitly called `exec()` on the database creation queries initialized alongside `DBManager` to fix "unused QSqlQuery" warnings
- Added version-conditional refactors to code utilizing `QList::toSet()` which was deprecated in Qt 5.14 to fix "toSet() is deprecated" warnings