### PR TITLE
Properly reload modern advertiser config

### DIFF
--- a/core/include/http_advertiser.h
+++ b/core/include/http_advertiser.h
@@ -32,6 +32,14 @@ struct advertiser_config {
     bool debug;
 };
 
+struct update_advertiser_config {
+    QString name;
+    QString description;
+    int players;
+    QUrl masterserver;
+    bool debug;
+};
+
 /**
  * @brief Represents the advertiser of the server. Sends current server information to masterserver.
  */
@@ -68,6 +76,12 @@ public slots:
      * @param config Configuration struct for the advertiser. Always includes ALL settings.
      */
     void setAdvertiserSettings(advertiser_config config);
+
+    /**
+     * @brief Sets the updated values being advertiser to masterserver.
+     * @param config Configuration struct for the advertiser. Only includes partial information, as ports can't be changed.
+     */
+    void updateAdvertiserSettings(update_advertiser_config config);
 
 private:
 

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -141,7 +141,12 @@ class Server : public QObject {
     /**
      * @brief Creates an HTTP advertiser config struct and emits it using server::reloadHTTPRequest.
      */
-    void reloadHTTPAdvertiserConfig();
+    void setHTTPAdvertiserConfig();
+
+    /**
+     * @brief Updates the modern advertiser configuration on configuration reload.
+     */
+    void updateHTTPAdvertiserConfig();
 
     /**
      * @brief The collection of all currently connected clients.
@@ -234,10 +239,16 @@ class Server : public QObject {
     void reloadRequest(QString p_name, QString p_desc);
 
     /**
-     * @brief Sends all necessary info for the new advertiser.
+     * @brief Sends all necessary info for the modern advertiser.
      * @param Struct that contains all configuration for the advertiser
      */
-    void reloadHTTPRequest(struct advertiser_config config);
+    void setHTTPConfiguration(struct advertiser_config config);
+
+    /**
+     * @brief Sends a partial update to the modern advertiser.
+     * @param Struct that contains partial information about the server to update the advertised information.
+     */
+    void updateHTTPConfiguration(struct update_advertiser_config config);
 
     /**
      * @brief Sends a modcall webhook request, emitted by AOClient::pktModcall.

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -412,7 +412,7 @@ void AOClient::cmdReload(int argc, QStringList argv)
 {
     ConfigManager::reloadSettings();
     emit server->reloadRequest(ConfigManager::serverName(), ConfigManager::serverDescription());
-    server->reloadHTTPAdvertiserConfig();
+    server->updateHTTPAdvertiserConfig();
     sendServerMessage("Reloaded configurations");
 }
 

--- a/core/src/http_advertiser.cpp
+++ b/core/src/http_advertiser.cpp
@@ -79,4 +79,13 @@ void HTTPAdvertiser::setAdvertiserSettings(advertiser_config config)
     msAdvertiseServer();
 }
 
+void HTTPAdvertiser::updateAdvertiserSettings(update_advertiser_config config)
+{
+    m_name = config.name;
+    m_description = config.description;
+    m_players = config.players;
+    m_masterserver = config.masterserver;
+    m_debug = config.debug;
+}
+
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -64,9 +64,11 @@ void Server::start()
 
         connect(httpAdvertiserTimer, &QTimer::timeout,
                 httpAdvertiser, &HTTPAdvertiser::msAdvertiseServer);
-        connect(this, &Server::reloadHTTPRequest,
+        connect(this, &Server::setHTTPConfiguration,
                 httpAdvertiser, &HTTPAdvertiser::setAdvertiserSettings);
-        reloadHTTPAdvertiserConfig();
+        connect(this, &Server::updateHTTPConfiguration,
+                httpAdvertiser, &HTTPAdvertiser::updateAdvertiserSettings);
+        setHTTPAdvertiserConfig();
         httpAdvertiserTimer->start(300000);
     }
 
@@ -255,7 +257,7 @@ int Server::getCharID(QString char_name)
     return -1; // character does not exist
 }
 
-void Server::reloadHTTPAdvertiserConfig()
+void Server::setHTTPAdvertiserConfig()
 {
     advertiser_config config;
     config.name = ConfigManager::serverName();
@@ -265,7 +267,19 @@ void Server::reloadHTTPAdvertiserConfig()
     config.players = ConfigManager::maxPlayers();
     config.masterserver = ConfigManager::advertiserHTTPIP();
     config.debug = ConfigManager::advertiserHTTPDebug();
-    emit reloadHTTPRequest(config);
+    emit setHTTPConfiguration(config);
+}
+
+void Server::updateHTTPAdvertiserConfig()
+{
+    update_advertiser_config config;
+    config.name = ConfigManager::serverName();
+    config.description = ConfigManager::serverDescription();
+    config.players = ConfigManager::maxPlayers();
+    config.masterserver = ConfigManager::advertiserHTTPIP();
+    config.debug = ConfigManager::advertiserHTTPDebug();
+    emit updateHTTPConfiguration(config);
+
 }
 
 void Server::allowMessage()


### PR DESCRIPTION
Corrects oversight that causes ports to be reloaded in case they change in the config. Since Akashi cannot change its port mid-operation, that information needs to be excluded during a reload.