### PR TITLE
Change the way UIDs are calculated.

### DIFF
--- a/core/include/server.h
+++ b/core/include/server.h
@@ -207,6 +207,13 @@ class Server : public QObject {
      */
     bool can_send_ic_messages = true;
 
+    /**
+     * @brief Frees the given UID, allowing it to be taken by new clients.
+     *
+     * @param id The UID to free.
+     */
+    void freeUID(const int id);
+
   public slots:
     /**
      * @brief Handles a new connection.
@@ -286,6 +293,11 @@ class Server : public QObject {
      * @brief The port through which the server will accept WebSocket connections.
      */
     int ws_port;
+
+    /**
+     * @brief A vector containing possible UIDs and whether or not they have been taken.
+     */
+    QVector<bool>* uid;
 };
 
 #endif // SERVER_H

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -214,6 +214,11 @@ class Server : public QObject {
      */
     void freeUID(const int id);
 
+    /**
+     * @brief Informs the server to resize the UID vectV53*mGr4xzmAGpYor.
+     */
+    void resizeUIDs();
+
   public slots:
     /**
      * @brief Handles a new connection.

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -66,6 +66,8 @@ void AOClient::clientDisconnected()
     if (l_updateLocks)
         arup(ARUPType::LOCKED, true);
     arup(ARUPType::CM, true);
+
+    server->freeUID(id);
 }
 
 void AOClient::handlePacket(AOPacket packet)

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -411,6 +411,7 @@ void AOClient::cmdBanInfo(int argc, QStringList argv)
 void AOClient::cmdReload(int argc, QStringList argv)
 {
     ConfigManager::reloadSettings();
+    server->resizeUIDs();
     emit server->reloadRequest(ConfigManager::serverName(), ConfigManager::serverDescription());
     server->reloadHTTPAdvertiserConfig();
     sendServerMessage("Reloaded configurations");

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -291,6 +291,11 @@ void Server::freeUID(const int id)
     uid->data()[id] = false;
 }
 
+void Server::resizeUIDs()
+{
+    uid->resize(ConfigManager::maxPlayers());
+}
+
 Server::~Server()
 {
     for (AOClient* client : clients) {


### PR DESCRIPTION
Change UIDs to use a vector with the size of the maximum number of players. When a client connects, it will use the first non-taken index to use as it's UID, and set that index as taken. When it disconnects, it will set that index to false. This should mitigate the problem of two clients choosing the same UID.

This should fix #169 