### PR TITLE
Add /notice, for moderators to be heard above the noise

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1929,6 +1929,16 @@ class AOClient : public QObject {
      * @return True if the password meets the requirements, otherwise false.
      */
     bool checkPasswordRequirements(QString username, QString password);
+
+    /**
+     * @brief Sends a server notice.
+     *
+     * @param notice The notice to send out.
+     *
+     * @param global Whether or not the notice should be server-wide.
+     */
+    void sendNotice(QString notice, bool global = false);
+
     
     /**
      * @brief Checks if a testimony contains '<' or '>'.

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1237,6 +1237,17 @@ class AOClient : public QObject {
      */
     void cmdNotice(int argc, QStringList argv);
 
+    /**
+     * @brief Pops up a notice for all clients in the server with a given message.
+     *
+     * @details Unlike cmdNotice, this command will send its notice to every client connected to the server.
+     *
+     * @see #cmdNotice
+     *
+     * @iscommand
+     */
+    void cmdNoticeGlobal(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -2090,6 +2101,7 @@ class AOClient : public QObject {
         {"ignorebglist",       {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}},
         {"ignore_bglist",      {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}},
         {"notice",             {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNotice}},
+        {"noticeg",            {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNoticeGlobal}},
     };
 
     /**

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -231,6 +231,7 @@ class AOClient : public QObject {
         {"FORCE_CHARSELECT",1ULL << 13},
         {"BYPASS_LOCKS",    1ULL << 14},
         {"IGNORE_BGLIST",   1ULL << 15},
+        {"SEND_NOTICE",     1ULL << 16},
         {"SUPER",          ~0ULL      }
     };
 
@@ -1223,6 +1224,19 @@ class AOClient : public QObject {
      */
     void cmdUpdateBan(int argc, QStringList argv);
 
+    /**
+     * @brief Pops up a notice for all clients in the targeted area with a given message.
+     *
+     * @details The only argument is the message to send. This command only works on clients with support for the BB#%
+     *
+     * generic message box packet (i.e. Attorney Online versions 2.9 and up). To support earlier versions (as well as to make the message
+     *
+     * re-readable if a user clicks out of it too fast) the message will also be sent in OOC to all affected clients.
+     *
+     * @iscommand
+     */
+    void cmdNotice(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -2074,7 +2088,8 @@ class AOClient : public QObject {
         {"update_ban",         {ACLFlags.value("BAN"),          3, &AOClient::cmdUpdateBan}},
         {"changepass",         {ACLFlags.value("NONE"),         1, &AOClient::cmdChangePassword}},
         {"ignorebglist",       {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}},
-        {"ignore_bglist",      {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}}
+        {"ignore_bglist",      {ACLFlags.value("IGNORE_BGLIST"),0, &AOClient::cmdIgnoreBgList}},
+        {"notice",             {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNotice}},
     };
 
     /**

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -212,7 +212,8 @@ bool AOClient::checkPasswordRequirements(QString username, QString password)
 void AOClient::sendNotice(QString notice, bool global)
 {
     QString message = "A moderator sent this ";
-    message += (global ? "server-wide " : "");
+    if (global)
+        message += "server-wide ";
     message += "notice:\n\n" + notice;
     sendServerMessageArea(message);
     AOPacket packet("BB", {message});

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -208,3 +208,16 @@ bool AOClient::checkPasswordRequirements(QString username, QString password)
     }
     return true;
 }
+
+void AOClient::sendNotice(QString notice, bool global)
+{
+    QString message = "A moderator sent this ";
+    message += (global ? "server-wide " : "");
+    message += "notice:\n\n" + notice;
+    sendServerMessageArea(message);
+    AOPacket packet("BB", {message});
+    if (global)
+        server->broadcast(packet);
+    else
+        server->broadcast(packet, current_area);
+}

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -520,5 +520,10 @@ void AOClient::cmdNotice(int argc, QStringList argv)
     QString message = "A moderator sent this notice:\n\n" + argv.join(" ");
     sendServerMessageArea(message);
     server->broadcast(AOPacket("BB", {message}), current_area);
-
+}
+void AOClient::cmdNoticeGlobal(int argc, QStringList argv)
+{
+    QString message = "A moderator sent this server-wide notice:\n\n" + argv.join(" ");
+    sendServerBroadcast(message);
+    server->broadcast(AOPacket("BB", {message}));
 }

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -514,3 +514,11 @@ void AOClient::cmdUpdateBan(int argc, QStringList argv)
     }
     sendServerMessage("Ban updated.");
 }
+
+void AOClient::cmdNotice(int argc, QStringList argv)
+{
+    QString message = "A moderator sent this notice:\n\n" + argv.join(" ");
+    sendServerMessageArea(message);
+    server->broadcast(AOPacket("BB", {message}), current_area);
+
+}

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -517,13 +517,9 @@ void AOClient::cmdUpdateBan(int argc, QStringList argv)
 
 void AOClient::cmdNotice(int argc, QStringList argv)
 {
-    QString message = "A moderator sent this notice:\n\n" + argv.join(" ");
-    sendServerMessageArea(message);
-    server->broadcast(AOPacket("BB", {message}), current_area);
+    sendNotice(argv.join(" "));
 }
 void AOClient::cmdNoticeGlobal(int argc, QStringList argv)
 {
-    QString message = "A moderator sent this server-wide notice:\n\n" + argv.join(" ");
-    sendServerBroadcast(message);
-    server->broadcast(AOPacket("BB", {message}));
+    sendNotice(argv.join(" "), true);
 }


### PR DESCRIPTION
/notice, when used, will send every user in the same area a packet that will cause a message box like this one to appear:

![image](https://user-images.githubusercontent.com/32779090/128166780-fed73dc3-1d4d-408b-9da6-0855c10a87b7.png)

After two seconds, the user is allowed to press "OK" and continue use of the application. This is useful for when there is too much chaos for a moderator's voice to be heard, or for when you want to epicly troll people I guess.