### PR TITLE
Set background in area data when /bg is used.

### DIFF
--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -467,6 +467,13 @@ class AreaData : public QObject {
     QString background() const;
 
     /**
+     * @brief Sets the background of the area.
+     *
+     * @see #AOClient::cmdSetBackground and #m_background
+     */
+    void setBackground(const QString f_background);
+
+    /**
      * @brief Returns if custom shownames are allowed in the area.
      *
      * @return See short description.

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -528,6 +528,11 @@ QString AreaData::background() const
     return m_background;
 }
 
+void AreaData::setBackground(const QString f_background)
+{
+    m_background = f_background;
+}
+
 bool AreaData::ignoreBgList()
 {
     return m_ignoreBgList;

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -251,7 +251,7 @@ void AOClient::cmdSetBackground(int argc, QStringList argv)
     AreaData* area = server->areas[current_area];
     if (authenticated || !area->bgLocked()) {
         if (server->backgrounds.contains(argv[0], Qt::CaseInsensitive) || area->ignoreBgList() == true) {
-            area->background() = argv[0];
+            area->setBackground(argv[0]);
             server->broadcast(AOPacket("BN", {argv[0]}), current_area);
             sendServerMessageArea(current_char + " changed the background to " + argv[0]);
         }


### PR DESCRIPTION
Currently, Akashi does not save the changed background in the area, meaning clients will default to the background of the config.

This commit addresses the issue by saving the new background in the area data, meaning it is persistent between people moving in and out of the area.

This PR addresses #178 