### PR TITLE
Add missing afk timeout configuration to sample config

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -57,6 +57,9 @@ maximum_characters=256
 ; The minimum time between IC messages, in miliseconds. The default value is fine for most cases.
 message_floodguard=250
 
+; The amount of seconds without interaction till a client is marked as AFK.
+afk_timeout = 300
+
 ; The URL of the server's remote repository, sent to the client during their initial handshake. Used by WebAO users for custom content.
 asset_url=
 


### PR DESCRIPTION
It's loaded from the config, so it should probably be added here.