### PR TITLE
Add ban webhook url option

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -86,16 +86,19 @@ max_dice=100
 webhook_enabled=false
 
 ; The URL of the discord webhook to send messages to. Must contain the webhook ID and token.
-webhook_url=
+webhook_modcall_url=
 
 ; Whether to attach a file containing the area log when a modcall message is sent to the webhook.
-webhook_sendfile=false
+webhook_modcall_sendfile=false
 
 ; Additional text to send with the webhook message. Usually for adding tags for role. Ensure the format is <@&[RoleID]>.
 webhook_content=
 
 ; Enables the ban webhook.
 webhook_ban_enabled = false
+
+; The URL of the ban discord webhook to send messages to. Must contain the webhook ID and token.
+webhook_ban_url=
 
 [Password]
 ; Whether or not to enforce password requirements. Only applicable under advanced authorization.

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -202,7 +202,7 @@ class ConfigManager {
      *
      * @return See short description.
      */
-    static QString discordWebhookUrl();
+    static QString discordModcallWebhookUrl();
 
     /**
      * @brief Returns the discord webhook content.
@@ -216,7 +216,7 @@ class ConfigManager {
      *
      * @return See short description.
      */
-    static bool discordWebhookSendFile();
+    static bool discordModcallWebhookSendFile();
 
     /**
      * @brief Returns true if the discord ban webhook is enabled.
@@ -224,6 +224,13 @@ class ConfigManager {
      * @return See short description.
      */
     static bool discordBanWebhookEnabled();
+
+    /**
+     * @brief Returns the Discord Ban Webhook URL.
+     *
+     * @return See short description.
+     */
+    static QString discordBanWebhookUrl();
 
     /**
      * @brief Returns true if password requirements should be enforced.

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -270,9 +270,9 @@ bool ConfigManager::discordWebhookEnabled()
     return m_settings->value("Discord/webhook_enabled", false).toBool();
 }
 
-QString ConfigManager::discordWebhookUrl()
+QString ConfigManager::discordModcallWebhookUrl()
 {
-    return m_settings->value("Discord/webhook_url", "").toString();
+    return m_settings->value("Discord/webhook_modcall_url", "").toString();
 }
 
 QString ConfigManager::discordWebhookContent()
@@ -280,14 +280,19 @@ QString ConfigManager::discordWebhookContent()
     return m_settings->value("Discord/webhook_content", "").toString();
 }
 
-bool ConfigManager::discordWebhookSendFile()
+bool ConfigManager::discordModcallWebhookSendFile()
 {
-    return m_settings->value("Discord/webhook_sendfile", false).toBool();
+    return m_settings->value("Discord/webhook_modcall_sendfile", false).toBool();
 }
 
 bool ConfigManager::discordBanWebhookEnabled()
 {
     return m_settings->value("Discord/webhook_ban_enabled", false).toBool();
+}
+
+QString ConfigManager::discordBanWebhookUrl()
+{
+    return m_settings->value("Discord/webhook_ban_url", "").toString();
 }
 
 bool ConfigManager::passwordRequirements()

--- a/core/src/discord.cpp
+++ b/core/src/discord.cpp
@@ -20,20 +20,18 @@
 Discord::Discord(QObject* parent) :
     QObject(parent)
 {
-    if (!QUrl(ConfigManager::discordWebhookUrl()).isValid())
-        qWarning("Invalid webhook URL!");
     m_nam = new QNetworkAccessManager();
     connect(m_nam, &QNetworkAccessManager::finished,
             this, &Discord::onReplyFinished);
-    m_request.setUrl(QUrl(ConfigManager::discordWebhookUrl()));
 }
 
 void Discord::onModcallWebhookRequested(const QString &f_name, const QString &f_area, const QString &f_reason, const QQueue<QString> &f_buffer)
 {
+    m_request.setUrl(QUrl(ConfigManager::discordModcallWebhookUrl()));
     QJsonDocument l_json = constructModcallJson(f_name, f_area, f_reason);
     postJsonWebhook(l_json);
 
-    if (ConfigManager::discordWebhookSendFile()) {
+    if (ConfigManager::discordModcallWebhookSendFile()) {
         QHttpMultiPart *l_multipart = constructLogMultipart(f_buffer);
         postMultipartWebhook(*l_multipart);
     }
@@ -41,6 +39,7 @@ void Discord::onModcallWebhookRequested(const QString &f_name, const QString &f_
 
 void Discord::onBanWebhookRequested(const QString &f_ipid, const QString &f_moderator, const QString &f_duration, const QString &f_reason, const int &f_banID)
 {
+    m_request.setUrl(QUrl(ConfigManager::discordBanWebhookUrl()));
     QJsonDocument l_json = constructBanJson(f_ipid,f_moderator, f_duration, f_reason, f_banID);
     postJsonWebhook(l_json);
 }


### PR DESCRIPTION
Allows ban webhooks to be send to another channel. Useful for public shaming