### PR TITLE
Fix QIODevice::read (QTcpSocket) device not open error

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -2181,7 +2181,7 @@ class AOClient : public QObject {
     /**
      * @brief The size, in bytes, of the last data the client sent to the server.
      */
-    int last_read;
+    int last_read = 0;
 
     /**
      * @brief A helper function for logging in a client as moderator.

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -23,6 +23,11 @@ void AOClient::clientData()
         socket->close();
     }
 
+    if (last_read == 0) { // i.e. this is the first packet we've been sent
+        if (!socket->waitForConnected(1000)) {
+            socket->close();
+        }
+    }
     QString data = QString::fromUtf8(socket->readAll());
     last_read = data.size();
 


### PR DESCRIPTION
this is done by waiting a maximum of one second to be certain a connection is established before beginning to read data from the socket

this needs testing by someone other than me