### PR TITLE
Implement help information handling

### DIFF
--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -361,193 +361,193 @@
    },
    {
       "name":"gimp",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/gimp [ClientID]",
+      "text":"Replaces a target client's in-character messages with strings randomly selected from gimp.txt. Takes the client id as the only argument."
    },
    {
       "name":"ungimp",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/ungimp [ClientID]",
+      "text":"Allows a gimped client to speak normally. User needs to be gimped to be ungimped. Takes the client id as the only argument."
    },
    {
       "name":"baninfo",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/baninfo [BanID]",
+      "text":"Looks up info on a ban."
    },
    {
       "name":"testify",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/testify",
+      "text":"Enables the testimony recorder in the area. The next message will automatically be used as the title of the testimony. This command takes no arguments."
    },
    {
       "name":"testimony",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/testimony",
+      "text":"Outputs the contents of the testimony recorder into OOC. This command takes no arguments."
    },
    {
       "name":"examine",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/testify",
+      "text":"Switches the testimony recorder into playback mode. If no testimony has been recorded, this command can't be used. This command takes no arguments."
    },
    {
       "name":"pause",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/pause",
+      "text":"Pauses testimony playback. This command takes no arguments."
    },
    {
       "name":"delete",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/delete",
+      "text":"Deletes the currently displayed testimony message from the testimony recorder. This command takes no arguments."
    },
    {
       "name":"update",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/update",
+      "text":"Updates the currently displayed testimony message with the next message said in IC chat. This command takes no arguments."
    },
    {
       "name":"add",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/add",
+      "text":"Adds the next IC message into the testimony recorder after the currently displayed message. This command takes no arguments."
    },
    {
       "name":"reload",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/reload",
+      "text":"Reloads the server configuration. This command takes no arguments."
    },
    {
       "name":"disemvovel",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/disemvovel [ClientID]",
+      "text":"Disemvovels a user, removing vovels from their IC messages. Takes the client ID as argument."
    },
    {
       "name":"undisemvovel",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"undisemvovel [ClientID]",
+      "text":"Removes the disemvovel from a user, allowing them to use vowels again."
    },
    {
       "name":"shake",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/shake [ClientID]",
+      "text":"Scrambles the words of a target client's in-character messages. The only argument is the client ID"
    },
    {
       "name":"unshake",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/unshake [ClientID",
+      "text":"llows a shaken client to speak normally."
    },
    {
       "name":"forceimmediate",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/forceimmediate",
+      "text":"Toggles immediate text processing in the current area. This command takes no arguments."
    },
    {
       "name":"force_noint_pres",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/force_noint_pres",
+      "text":"Toggles immediate text processing in the current area. This command takes no arguments."
    },
    {
       "name":"allowiniswap",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/allowiniswap",
+      "text":"Toggles whether iniswaps are allowed in the current area. This command takes no arguments."
    },
    {
       "name":"allow_iniswap",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/allow_iniswap",
+      "text":"Toggles whether iniswaps are allowed in the current area. This command takes no arguments."
    },
    {
       "name":"afk",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/afk",
+      "text":"Toggles whether this client is considered AFK. This command takes no arguments."
    },
    {
       "name":"savetestimony",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/savetestimony [Name]",
+      "text":"Saves a testimony recording to the servers storage. Argument is the name of the testimony."
    },
    {
       "name":"loadtestimony",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/loadtestimony [Name]",
+      "text":"oads testimony for the testimony replay. Argument is the testimony name."
    },
    {
       "name":"permitsaving",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/permitsaving [ClientID]",
+      "text":"Grants a client the temporary permission to save a testimony. Argument is the client ID"
    },
    {
       "name":"mutepm",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/mutepm",
+      "text":"oggles whether a client will recieve private messages or not. This command takes no arguments."
    },
    {
       "name":"oocmute",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/oocmute [ClientID]",
+      "text":"OOC-mutes a client. Argument is the client ID."
    },
    {
       "name":"ooc_mute",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/ooc_mute [ClientID]",
+      "text":"OOC-mutes a client. Argument is the client ID."
    },
    {
       "name":"oocunmute",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/oocunmute [ClientID",
+      "text":"Removes the OOC-muted status from a client. Argument is the client ID."
    },
    {
       "name":"ooc_unmute",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/ooc_unmute [ClientID]",
+      "text":"Removes the OOC-muted status from a client. Argument is the client ID."
    },
    {
       "name":"blockwtce",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/blockwtce [ClientID]",
+      "text":"WTCE-blocks a client. Argument is the client ID."
    },
    {
       "name":"block_wtce",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/block_wtce [ClientID]",
+      "text":"WTCE-blocks a client. Argument is the client ID."
    },
    {
       "name":"unblockwtce",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/unblockwtce [ClientID]",
+      "text":"WTCE-unblocks a client. Argument is the client ID."
    },
    {
       "name":"unlock_wtce",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/unblock_wtce [ClientID]",
+      "text":"WTCE-unblocks a client. Argument is the client ID."
    },
    {
       "name":"blockdj",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/blockdj [ClientID]",
+      "text":"DJ-blocks a client. Argument is the client ID."
    },
    {
       "name":"block_dj",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"block_dj [ClientID]",
+      "text":"DJ-blocks a client. Argument is the client ID."
    },
    {
       "name":"unblockdj",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/unblockdj [ClientID]",
+      "text":"Removes the DJ-blocked status from a client. Argument is the client ID."
    },
    {
       "name":"unblock_dj",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/unblock_dj [ClientID]",
+      "text":"Removes the DJ-blocked status from a client. Argument is the client ID."
    },
    {
       "name":"charcurse",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/charcurse [ClientID|CharacterName]",
+      "text":"Restricts a target client to a set of characters that they can switch from, blocking them from other characters."
    },
    {
       "name":"uncharcurse",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"uncharcurse [ClientID]",
+      "text":"Removes the charcurse status from a client. Argument is the ClientID"
    },
    {
       "name":"charselect",
@@ -556,77 +556,77 @@
    },
    {
       "name":"togglemusic",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/tooglemusic",
+      "text":"Toggles music playing in the current area. This command takes no arguments."
    },
    {
       "name":"a",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/a [Area|Message]",
+      "text":"Sends a message to an area that you a CM in."
    },
    {
       "name":"s",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/s [Message]",
+      "text":"Send a message to all areas that you are a CM in."
    },
    {
       "name":"kickuid",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/kickuid [UserID|Message]",
+      "text":"Kicks a client from the server, forcibly severing its connection to the server. This command only kicks the client with the user ID. Argument is the User ID."
    },
    {
       "name":"kick_uid",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/kick_uid [UserID|Message]",
+      "text":"Kicks a client from the server, forcibly severing its connection to the server. This command only kicks the client with the user ID. Argument is the User ID."
    },
    {
       "name":"firstperson",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/firstperson",
+      "text":"Toggle whether the client's messages will be sent in first person mode. This command takes no arguments."
    },
    {
       "name":"updateban",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/updateban [BanID|Field|UpdateValue]",
+      "text":"Updates a ban in the database, changing either its reason or duration. First argument is the ban ID. Second is the field, 'reason' or 'duration'. Last argument is either the new duration or reason."
    },
    {
       "name":"update_ban",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/update_ban [BanID|Field|UpdateValue]",
+      "text":"Updates a ban in the database, changing either its reason or duration. First argument is the ban ID. Second is the field, 'reason' or 'duration'. Last argument is either the new duration or reason."
    },
    {
       "name":"changepass",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/changepass [Password|*Moderator]",
+      "text":"Changes a moderator's password. First argument is the new password. Optional second argument is the moderator name."
    },
    {
       "name":"ignorebglist",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/ignorebglist",
+      "text":"Toggles whether the BG list is ignored in an area. This command takes no arguments."
    },
    {
       "name":"ignore_bglist",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/ignore_bglist",
+      "text":"Toggles whether the BG list is ignored in an area. This command takes no arguments."
    },
    {
       "name":"notice",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/notice [Message]",
+      "text":"Pops up a notice for all clients in the targeted area with a given message. Only argument is the message."
    },
    {
       "name":"noticeg",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/noticeg [Message]",
+      "text":"Pops up a notice for all clients in the server with a given message. Only argument is the message."
    },
    {
       "name":"togglejukebox",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/togglejukebox",
+      "text":"Enables/Disables the Jukebox in the area. This command takes no arguments."
    },
    {
       "name":"help",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/help [CommandName]",
+      "text":"Shows you information about a command, if available. Only argument is the command name."
    }
 ]

--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -591,7 +591,7 @@
    },
    {
       "name":"update_ban",
-      "usage":"/update_ban <BanID> <Field> [Duration|Reason]",
+      "usage":"/update_ban <BanID> ['duration'|'reason'] <New Value>",
       "text":"Updates a ban in the database, changing either its reason or duration. First argument is the ban ID. Second is the field, 'reason' or 'duration'. Last argument is either the new duration or reason."
    },
    {

--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -3,5 +3,640 @@
     "name": "foo",
     "usage": "/foo <bar> [baz|qux]",
     "text": "A sample explanation."
-  }
+  },
+  {
+    "name": "foo",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "foo",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "login",
+    "usage": "/login",
+    "text": "Activates the login dialogue to enter your credentials. This command takes no arguments."
+  },
+  {
+    "name": "getareas",
+    "usage": "/getareas",
+    "text": "Lists all clients in all areas. This command takes no arguments."
+  },
+  {
+    "name": "getarea",
+    "usage": "/getarea",
+    "text": "Lists all clients in the area the caller is in. This command takes no arguments."
+  },
+  {
+    "name": "ban",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "kick",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "changeauth",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "rootpass",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "background",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "bg",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "bglock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "bgunlock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "adduser",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "listperms",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "addperm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "removeperm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "listusers",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "logout",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "pos",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "g",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "need",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "coinflip",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "roll",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "rollp",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "doc",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "cleardoc",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "cm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "uncm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "invite",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "uninvite",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "lock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "area_lock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "spectatable",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "area_spectate",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unlock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "area_unlock",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "timer",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "play",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "areakick",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "area_kick",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "randomchar",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "switch",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "toggleglobal",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "mods",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "commands",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "status",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "forcepos",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "currentmusic",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "pm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "evidence_mod",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "motd",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "announce",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "m",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "gm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "mute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unmute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "bans",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unban",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "removeuser",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "subtheme",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "about",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "evidence_swap",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notecard",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notecardreveal",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notecard_reveal",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notecardclear",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notecard_clear",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "8ball",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "lm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "judgelog",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "allowblankposting",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "allow_blankposting",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "gimp",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "ungimp",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "baninfo",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "testify",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "testimony",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "examine",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "pause",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "delete",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "update",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "add",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "reload",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "disemvovel",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "undisemvovel",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "shake",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unshake",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "forceimmediate",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "force_noint_pres",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "allowiniswap",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "allow_iniswap",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "afk",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "savetestimony",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "loadtestimony",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "permitsaving",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "mutepm",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "oocmute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "ooc_mute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "oocunmute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "ooc_unmute",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "blockwtce",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "block_wtce",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unblockwtce",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unlock_wtce",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "blockdj",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "block_dj",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unblockdj",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "unblock_dj",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "charcurse",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "uncharcurse",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "charselect",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "togglemusic",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "a",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "s",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "kickuid",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "kick_uid",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "firstperson",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "updateban",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "update_ban",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "changepass",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "ignorebglist",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "ignore_bglist",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "notice",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "noticeg",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "togglejukebox",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
+  {
+    "name": "help",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  },
 ]

--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -21,12 +21,12 @@
    },
    {
       "name":"ban",
-      "usage":"/ban [IPID|Duration|Reason]",
-      "text":"Bans a client from the server, orcibly disconnecting them and disallowing their return."
+      "usage":"/ban <IPID> <Duration> <Reason>",
+      "text":"Bans a client from the server, forcibly disconnecting them and disallowing their return."
    },
    {
       "name":"kick",
-      "usage":"/kick [IPID|Reason]",
+      "usage":"/kick <IPID> <Reason>",
       "text":"Kicks a client from the server, forcibly disconnecting them."
    },
    {
@@ -36,17 +36,17 @@
    },
    {
       "name":"rootpass",
-      "usage":"/rootpass [Password]",
+      "usage":"/rootpass <Password>",
       "text":"Sets the root user's password."
    },
    {
       "name":"background",
-      "usage":"/background [Name]",
+      "usage":"/background <Background>",
       "text":"Changes the background of the current area."
    },
    {
       "name":"bg",
-      "usage":"/bg [Name]",
+      "usage":"/bg <Background>",
       "text":"Changes the background of the current area."
    },
    {
@@ -61,22 +61,22 @@
    },
    {
       "name":"adduser",
-      "usage":"/adduser [Username|Password]",
+      "usage":"/adduser <Username> <Password>",
       "text":"Adds a user to the moderators in advanced authorisation type."
    },
    {
       "name":"listperms",
-      "usage":"/listperms *[Username]",
+      "usage":"/listperms 'Username'",
       "text":"Lists the permission of a given user. When called with an argument it shows the user's permission."
    },
    {
       "name":"addperm",
-      "usage":"/addperm[Username|Permission]",
+      "usage":"/addperm <Username> <Permission>",
       "text":"Adds permissions to a given user."
    },
    {
       "name":"removeperm",
-      "usage":"/removeperm {Username|Permission]",
+      "usage":"/removeperm <Username> <Permission>",
       "text":"Removes permissions from a given user."
    },
    {
@@ -91,17 +91,17 @@
    },
    {
       "name":"pos",
-      "usage":"/pos [Position]",
+      "usage":"/pos <Position>",
       "text":"Changes the client's position."
    },
    {
       "name":"g",
-      "usage":"/g [Message]",
+      "usage":"/g <Message>",
       "text":"Sends a global message (i.e., all clients in the server will be able to see it)."
    },
    {
       "name":"need",
-      "usage":"/need [Message]",
+      "usage":"/need <Message>",
       "text":"A global message expressing that the client needs something (generally: players for something)."
    },
    {
@@ -111,17 +111,17 @@
    },
    {
       "name":"roll",
-      "usage":"/roll [Faces|Dice]",
+      "usage":"/roll 'face' 'die'",
       "text":"Rools dice and sends the results to the area. The first argument is the amount of faces each die should have. The second argument is the amount of dice that should be rolled. Both arguments are optional."
    },
    {
       "name":"rollp",
-      "usage":"/foo <bar> [baz|qux]",
+      "usage":"/rollp 'face' 'die'",
       "text":"Rolls dice, but sends the results in private to the roller. The first argument is the amount of faces each die should have. The second argument is the amount of dice that should be rolled. Both arguments are optional."
    },
    {
       "name":"doc",
-      "usage":"/doc [Link/Text]",
+      "usage":"/doc <document>",
       "text":"Sets the `/doc` to a custom text."
    },
    {
@@ -131,7 +131,7 @@
    },
    {
       "name":"cm",
-      "usage":"/cm *[ID]",
+      "usage":"/cm 'ID'",
       "text":"Promotes a client to CM status. If called with a user ID as an argument, and the caller is a CM, promotes the target client to CM status."
    },
    {
@@ -141,13 +141,13 @@
    },
    {
       "name":"invite",
-      "usage":"/invite [ID]",
+      "usage":"/invite <ID>",
       "text":"Invites a client to the area."
    },
    {
       "name":"uninvite",
-      "usage":"/uninvite [ID]",
-      "text":"Uninvites a client to the area."
+      "usage":"/uninvite <ID>",
+      "text":"Uninvites a client from. the area."
    },
    {
       "name":"lock",
@@ -181,22 +181,22 @@
    },
    {
       "name":"timer",
-      "usage":"/timer *[TimerID|Duration]",
+      "usage":"/timer 'Timer' 'Duration'",
       "text":"Gets or sets the global or one of the area-specific timers. If called without arguments, sends an out-of-character message listing the statuses of both the global timer and the area-specific timers. If called with one argument, and that argument is between `0` and `4` (inclusive on both ends), sends an out-of-character message about the status of the given timer, where `0` is the global timer, and the remaining numbers are the first, second, third and fourth timers in the current area."
    },
    {
       "name":"play",
-      "usage":"/play [Song]",
+      "usage":"/play <Song>",
       "text":"Plays music in the area. Can play either a local file or a URL."
    },
    {
       "name":"areakick",
-      "usage":"/areakick [ID]",
+      "usage":"/areakick <ID>",
       "text":"Kicks a client from the area, moving them back to the default area."
    },
    {
       "name":"area_kick",
-      "usage":"/area_kick [ID]",
+      "usage":"/area_kick <ID>",
       "text":"Kicks a client from the area, moving them back to the default area."
    },
    {
@@ -206,7 +206,7 @@
    },
    {
       "name":"switch",
-      "usage":"/switch [CharacterID]",
+      "usage":"/switch <ID>",
       "text":"Switches to a different character based on character ID."
    },
    {
@@ -226,13 +226,13 @@
    },
    {
       "name":"status",
-      "usage":"/status [Status]",
+      "usage":"/status <Status>",
       "text":"Changes the status of the current area."
    },
    {
       "name":"forcepos",
-      "usage":"/forcepos [ID|Position]",
-      "text":"Forces a client, or all clients in the area, to a specific position. The first argument is the client's ID or * for all client. The second argument is the position to force the clients to."
+      "usage":"/forcepos <ID> <Position>",
+      "text":"Forces a client, or all clients in the area, to a specific position. The first argument is the client's ID or * for all clients. The second argument is the position to force the clients to."
    },
    {
       "name":"currentmusic",
@@ -241,42 +241,42 @@
    },
    {
       "name":"pm",
-      "usage":"/pm [ID|Message]",
+      "usage":"/pm <ID> <Message>",
       "text":"Sends a direct message to another client on the server based on ID."
    },
    {
       "name":"evidence_mod",
-      "usage":"/evidence_mod [EvidenceMod]",
+      "usage":"/evidence_mod <EvidenceMod>",
       "text":"Changes the evidence mod in the area."
    },
    {
       "name":"motd",
-      "usage":"/motd *[Message]",
-      "text":"Gets or sets the server's Message Of The Day. If called without argument, gets the MOTD. If it has a message, sets the message as the MOTD."
+      "usage":"/motd 'Message'",
+      "text":"Gets or sets the server's Message Of The Day. If called without an argument, gets the MOTD. If it has a message, sets the message as the MOTD."
    },
    {
       "name":"announce",
-      "usage":"/announce [Message]",
+      "usage":"/announce <Message>",
       "text":"Sends out a decorated global message, for announcements."
    },
    {
       "name":"m",
-      "usage":"/m [Message]",
+      "usage":"/m <Message>",
       "text":"Sends a message in the server-wide, moderator only chat."
    },
    {
       "name":"gm",
-      "usage":"/gm [Message]",
+      "usage":"/gm <Message>",
       "text":"Sends out a global message that is marked with an `[M]` to mean it is coming from a moderator."
    },
    {
       "name":"mute",
-      "usage":"/mute [ClientID]",
+      "usage":"/mute <ID>",
       "text":"Mutes a client."
    },
    {
       "name":"unmute",
-      "usage":"/unmute [ClientID]",
+      "usage":"/unmute <ID>",
       "text":"Removes the muted status from a client."
    },
    {
@@ -286,17 +286,17 @@
    },
    {
       "name":"unban",
-      "usage":"/unban [BanID]",
+      "usage":"/unban <ID>",
       "text":"Removes a ban from the database."
    },
    {
       "name":"removeuser",
-      "usage":"/removeuser [Username]",
+      "usage":"/removeuser <Username>",
       "text":"Removes a user from the moderators in `advanced` authorisation type."
    },
    {
       "name":"subtheme",
-      "usage":"/subtheme [Theme]",
+      "usage":"/subtheme <Theme>",
       "text":"Changes the subtheme of the clients in the current area."
    },
    {
@@ -306,13 +306,13 @@
    },
    {
       "name":"evidence_swap",
-      "usage":"/foo [EvidenceID|EvidenceID]",
+      "usage":"/evidence_swap <EvidenceID> <EvidenceID>",
       "text":"Changes position of two pieces of evidence in the area."
    },
    {
       "name":"notecard",
-      "usage":"/notecard [Message]",
-      "text":"Writes a note card in the current area. he note card is not readable until all note cards in the area are revealed by a CM. A message will appear to all clients in the area indicating that a note card has been written."
+      "usage":"/notecard <Message>",
+      "text":"Writes a notecard in the current area. The notecard is not readable until all note cards in the area are revealed by a CM. A message will appear to all clients in the area indicating that a notecard has been written."
    },
    {
       "name":"notecardreveal",
@@ -327,21 +327,21 @@
    {
       "name":"notecardclear",
       "usage":"/notecardclear",
-      "text":"Erases the client's note card from the area's list of cards. A message will appear to all clients in the area indicating that a note card has been erased. This command takes no arguments."
+      "text":"Erases the client's notecard from the area's list of cards. A message will appear to all clients in the area indicating that a notecard has been erased. This command takes no arguments."
    },
    {
       "name":"notecard_clear",
       "usage":"/notecard_clear",
-      "text":"Erases the client's note card from the area's list of cards. A message will appear to all clients in the area indicating that a note card has been erased. This command takes no arguments."
+      "text":"Erases the client's notecard from the area's list of cards. A message will appear to all clients in the area indicating that a notecard has been erased. This command takes no arguments."
    },
    {
       "name":"8ball",
-      "usage":"/8ball [Question]",
+      "usage":"/8ball <Question>",
       "text":"Randomly selects an answer from 8ball.txt to a question."
    },
    {
       "name":"lm",
-      "usage":"/lm [Message]",
+      "usage":"/lm <Message>",
       "text":"Sends out a local message that is marked with an `[M]` to mean it is coming from a moderator."
    },
    {
@@ -352,26 +352,26 @@
    {
       "name":"allowblankposting",
       "usage":"allowblankposting",
-      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense this also allows you to disable blankposting."
+      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense, this also allows you to disable blankposting."
    },
    {
       "name":"allow_blankposting",
       "usage":"/allow_blankposting",
-      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense this also allows you to disable blankposting."
+      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense, this also allows you to disable blankposting."
    },
    {
       "name":"gimp",
-      "usage":"/gimp [ClientID]",
+      "usage":"/gimp <ID>",
       "text":"Replaces a target client's in-character messages with strings randomly selected from gimp.txt. Takes the client id as the only argument."
    },
    {
       "name":"ungimp",
-      "usage":"/ungimp [ClientID]",
-      "text":"Allows a gimped client to speak normally. User needs to be gimped to be ungimped. Takes the client id as the only argument."
+      "usage":"/ungimp <ID>",
+      "text":"Allows a gimped client to speak normally. The user needs to be gimped to be ungimped. Takes the client id as the only argument."
    },
    {
       "name":"baninfo",
-      "usage":"/baninfo [BanID]",
+      "usage":"/baninfo <BanID>",
       "text":"Looks up info on a ban."
    },
    {
@@ -416,22 +416,22 @@
    },
    {
       "name":"disemvovel",
-      "usage":"/disemvovel [ClientID]",
-      "text":"Disemvovels a user, removing vovels from their IC messages. Takes the client ID as argument."
+      "usage":"/disemvovel <ID>",
+      "text":"Disemvovels a user, removing vowels from their IC messages. Takes the client ID as an argument."
    },
    {
       "name":"undisemvovel",
-      "usage":"undisemvovel [ClientID]",
+      "usage":"undisemvovel <ID>",
       "text":"Removes the disemvovel from a user, allowing them to use vowels again."
    },
    {
       "name":"shake",
-      "usage":"/shake [ClientID]",
+      "usage":"/shake <ID>",
       "text":"Scrambles the words of a target client's in-character messages. The only argument is the client ID"
    },
    {
       "name":"unshake",
-      "usage":"/unshake [ClientID",
+      "usage":"/unshake <ID>",
       "text":"llows a shaken client to speak normally."
    },
    {
@@ -447,7 +447,7 @@
    {
       "name":"allowiniswap",
       "usage":"/allowiniswap",
-      "text":"Toggles whether iniswaps are allowed in the current area. This command takes no arguments."
+      "text":"Toggles whether iniswaps are allowed in the current area. For no apparent reason, this also can be used to disable it. This command takes no arguments."
    },
    {
       "name":"allow_iniswap",
@@ -461,98 +461,98 @@
    },
    {
       "name":"savetestimony",
-      "usage":"/savetestimony [Name]",
-      "text":"Saves a testimony recording to the servers storage. Argument is the name of the testimony."
+      "usage":"/savetestimony <Name>",
+      "text":"Saves a testimony recording to the server's storage. Argument is the name of the testimony."
    },
    {
       "name":"loadtestimony",
-      "usage":"/loadtestimony [Name]",
-      "text":"oads testimony for the testimony replay. Argument is the testimony name."
+      "usage":"/loadtestimony <Name>",
+      "text":"Loads testimony for the testimony replay. Argument is the testimony name."
    },
    {
       "name":"permitsaving",
-      "usage":"/permitsaving [ClientID]",
+      "usage":"/permitsaving <ID>",
       "text":"Grants a client the temporary permission to save a testimony. Argument is the client ID"
    },
    {
       "name":"mutepm",
       "usage":"/mutepm",
-      "text":"oggles whether a client will recieve private messages or not. This command takes no arguments."
+      "text":"Toggles whether a client will recieve private messages or not. This command takes no arguments."
    },
    {
       "name":"oocmute",
-      "usage":"/oocmute [ClientID]",
+      "usage":"/oocmute <ID>",
       "text":"OOC-mutes a client. Argument is the client ID."
    },
    {
       "name":"ooc_mute",
-      "usage":"/ooc_mute [ClientID]",
+      "usage":"/ooc_mute <ID>",
       "text":"OOC-mutes a client. Argument is the client ID."
    },
    {
       "name":"oocunmute",
-      "usage":"/oocunmute [ClientID",
+      "usage":"/oocunmute <ID>",
       "text":"Removes the OOC-muted status from a client. Argument is the client ID."
    },
    {
       "name":"ooc_unmute",
-      "usage":"/ooc_unmute [ClientID]",
+      "usage":"/ooc_unmute <ID>",
       "text":"Removes the OOC-muted status from a client. Argument is the client ID."
    },
    {
       "name":"blockwtce",
-      "usage":"/blockwtce [ClientID]",
+      "usage":"/blockwtce <ID>",
       "text":"WTCE-blocks a client. Argument is the client ID."
    },
    {
       "name":"block_wtce",
-      "usage":"/block_wtce [ClientID]",
+      "usage":"/block_wtce <ID>",
       "text":"WTCE-blocks a client. Argument is the client ID."
    },
    {
       "name":"unblockwtce",
-      "usage":"/unblockwtce [ClientID]",
+      "usage":"/unblockwtce <ID>",
       "text":"WTCE-unblocks a client. Argument is the client ID."
    },
    {
       "name":"unlock_wtce",
-      "usage":"/unblock_wtce [ClientID]",
+      "usage":"/unblock_wtce <ID>",
       "text":"WTCE-unblocks a client. Argument is the client ID."
    },
    {
       "name":"blockdj",
-      "usage":"/blockdj [ClientID]",
+      "usage":"/blockdj <ID>",
       "text":"DJ-blocks a client. Argument is the client ID."
    },
    {
       "name":"block_dj",
-      "usage":"block_dj [ClientID]",
+      "usage":"block_dj <ID>",
       "text":"DJ-blocks a client. Argument is the client ID."
    },
    {
       "name":"unblockdj",
-      "usage":"/unblockdj [ClientID]",
+      "usage":"/unblockdj <ID>",
       "text":"Removes the DJ-blocked status from a client. Argument is the client ID."
    },
    {
       "name":"unblock_dj",
-      "usage":"/unblock_dj [ClientID]",
+      "usage":"/unblock_dj <ID>",
       "text":"Removes the DJ-blocked status from a client. Argument is the client ID."
    },
    {
       "name":"charcurse",
-      "usage":"/charcurse [ClientID|CharacterName]",
+      "usage":"/charcurse <ClientID> <CharacterName>",
       "text":"Restricts a target client to a set of characters that they can switch from, blocking them from other characters."
    },
    {
       "name":"uncharcurse",
-      "usage":"uncharcurse [ClientID]",
+      "usage":"uncharcurse <ID>",
       "text":"Removes the charcurse status from a client. Argument is the ClientID"
    },
    {
       "name":"charselect",
-      "usage":"/foo <bar> [baz|qux]",
-      "text":"A sample explanation."
+      "usage":"/charselect 'ID'",
+      "text":"Forces yourself into the charselect screen. If used with a client ID, it forces that client back into the charselect screen."
    },
    {
       "name":"togglemusic",
@@ -561,22 +561,22 @@
    },
    {
       "name":"a",
-      "usage":"/a [Area|Message]",
+      "usage":"/a <Area> <Message>",
       "text":"Sends a message to an area that you a CM in."
    },
    {
       "name":"s",
-      "usage":"/s [Message]",
+      "usage":"/s <Message>",
       "text":"Send a message to all areas that you are a CM in."
    },
    {
       "name":"kickuid",
-      "usage":"/kickuid [UserID|Message]",
+      "usage":"/kickuid <ID> <Message>",
       "text":"Kicks a client from the server, forcibly severing its connection to the server. This command only kicks the client with the user ID. Argument is the User ID."
    },
    {
       "name":"kick_uid",
-      "usage":"/kick_uid [UserID|Message]",
+      "usage":"/kick_uid <ID> <Message>",
       "text":"Kicks a client from the server, forcibly severing its connection to the server. This command only kicks the client with the user ID. Argument is the User ID."
    },
    {
@@ -586,18 +586,18 @@
    },
    {
       "name":"updateban",
-      "usage":"/updateban [BanID|Field|UpdateValue]",
+      "usage":"/updateban <BanID> <Field> [Duration|Reason]",
       "text":"Updates a ban in the database, changing either its reason or duration. First argument is the ban ID. Second is the field, 'reason' or 'duration'. Last argument is either the new duration or reason."
    },
    {
       "name":"update_ban",
-      "usage":"/update_ban [BanID|Field|UpdateValue]",
+      "usage":"/update_ban <BanID> <Field> [Duration|Reason]",
       "text":"Updates a ban in the database, changing either its reason or duration. First argument is the ban ID. Second is the field, 'reason' or 'duration'. Last argument is either the new duration or reason."
    },
    {
       "name":"changepass",
-      "usage":"/changepass [Password|*Moderator]",
-      "text":"Changes a moderator's password. First argument is the new password. Optional second argument is the moderator name."
+      "usage":"/changepass <Password> 'Moderator'",
+      "text":"Changes a moderator's password. The first argument is the new password. The optional second argument is the moderator name."
    },
    {
       "name":"ignorebglist",
@@ -611,13 +611,13 @@
    },
    {
       "name":"notice",
-      "usage":"/notice [Message]",
-      "text":"Pops up a notice for all clients in the targeted area with a given message. Only argument is the message."
+      "usage":"/notice <Message>",
+      "text":"Pops up a notice for all clients in the targeted area with a given message. The only argument is the message."
    },
    {
       "name":"noticeg",
-      "usage":"/noticeg [Message]",
-      "text":"Pops up a notice for all clients in the server with a given message. Only argument is the message."
+      "usage":"/noticeg <Message>",
+      "text":"Pops up a notice for all clients in the server with a given message. The only argument is the message."
    },
    {
       "name":"togglejukebox",
@@ -626,7 +626,7 @@
    },
    {
       "name":"help",
-      "usage":"/help [CommandName]",
-      "text":"Shows you information about a command, if available. Only argument is the command name."
+      "usage":"/help <Command>",
+      "text":"Shows you information about a command, if available. The only argument is the command name. About Syntax : <Argument> are mandatory arguments. 'Argument' are optional arguments. [Argument|OtherArgument] is that two argument types are valid, but only one can be used."
    }
 ]

--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -1,642 +1,632 @@
 [
-  {
-    "name": "foo",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "foo",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "foo",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "login",
-    "usage": "/login",
-    "text": "Activates the login dialogue to enter your credentials. This command takes no arguments."
-  },
-  {
-    "name": "getareas",
-    "usage": "/getareas",
-    "text": "Lists all clients in all areas. This command takes no arguments."
-  },
-  {
-    "name": "getarea",
-    "usage": "/getarea",
-    "text": "Lists all clients in the area the caller is in. This command takes no arguments."
-  },
-  {
-    "name": "ban",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "kick",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "changeauth",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "rootpass",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "background",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "bg",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "bglock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "bgunlock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "adduser",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "listperms",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "addperm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "removeperm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "listusers",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "logout",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "pos",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "g",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "need",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "coinflip",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "roll",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "rollp",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "doc",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "cleardoc",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "cm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "uncm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "invite",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "uninvite",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "lock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "area_lock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "spectatable",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "area_spectate",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unlock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "area_unlock",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "timer",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "play",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "areakick",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "area_kick",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "randomchar",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "switch",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "toggleglobal",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "mods",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "commands",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "status",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "forcepos",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "currentmusic",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "pm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "evidence_mod",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "motd",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "announce",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "m",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "gm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "mute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unmute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "bans",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unban",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "removeuser",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "subtheme",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "about",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "evidence_swap",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notecard",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notecardreveal",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notecard_reveal",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notecardclear",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notecard_clear",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "8ball",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "lm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "judgelog",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "allowblankposting",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "allow_blankposting",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "gimp",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "ungimp",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "baninfo",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "testify",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "testimony",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "examine",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "pause",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "delete",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "update",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "add",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "reload",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "disemvovel",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "undisemvovel",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "shake",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unshake",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "forceimmediate",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "force_noint_pres",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "allowiniswap",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "allow_iniswap",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "afk",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "savetestimony",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "loadtestimony",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "permitsaving",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "mutepm",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "oocmute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "ooc_mute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "oocunmute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "ooc_unmute",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "blockwtce",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "block_wtce",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unblockwtce",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unlock_wtce",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "blockdj",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "block_dj",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unblockdj",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "unblock_dj",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "charcurse",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "uncharcurse",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "charselect",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "togglemusic",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "a",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "s",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "kickuid",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "kick_uid",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "firstperson",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "updateban",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "update_ban",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "changepass",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "ignorebglist",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "ignore_bglist",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "notice",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "noticeg",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "togglejukebox",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
-  {
-    "name": "help",
-    "usage": "/foo <bar> [baz|qux]",
-    "text": "A sample explanation."
-  },
+   {
+      "name":"foo",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"login",
+      "usage":"/login",
+      "text":"Activates the login dialogue to enter your credentials. This command takes no arguments."
+   },
+   {
+      "name":"getareas",
+      "usage":"/getareas",
+      "text":"Lists all clients in all areas. This command takes no arguments."
+   },
+   {
+      "name":"getarea",
+      "usage":"/getarea",
+      "text":"Lists all clients in the area the caller is in. This command takes no arguments."
+   },
+   {
+      "name":"ban",
+      "usage":"/ban [IPID|Duration|Reason]",
+      "text":"Bans a client from the server, orcibly disconnecting them and disallowing their return."
+   },
+   {
+      "name":"kick",
+      "usage":"/kick [IPID|Reason]",
+      "text":"Kicks a client from the server, forcibly disconnecting them."
+   },
+   {
+      "name":"changeauth",
+      "usage":"/changeauth",
+      "text":"A helper to change the authorisation for moderators from simple to advanced."
+   },
+   {
+      "name":"rootpass",
+      "usage":"/rootpass [Password]",
+      "text":"Sets the root user's password."
+   },
+   {
+      "name":"background",
+      "usage":"/background [Name]",
+      "text":"Changes the background of the current area."
+   },
+   {
+      "name":"bg",
+      "usage":"/bg [Name]",
+      "text":"Changes the background of the current area."
+   },
+   {
+      "name":"bglock",
+      "usage":"/bglock",
+      "text":"Locks the background, preventing it from being changed. This command takes no arguments."
+   },
+   {
+      "name":"bgunlock",
+      "usage":"/bgunlock",
+      "text":"Unlocks the background, allowing it to be changed again."
+   },
+   {
+      "name":"adduser",
+      "usage":"/adduser [Username|Password]",
+      "text":"Adds a user to the moderators in advanced authorisation type."
+   },
+   {
+      "name":"listperms",
+      "usage":"/listperms *[Username]",
+      "text":"Lists the permission of a given user. When called with an argument it shows the user's permission."
+   },
+   {
+      "name":"addperm",
+      "usage":"/addperm[Username|Permission]",
+      "text":"Adds permissions to a given user."
+   },
+   {
+      "name":"removeperm",
+      "usage":"/removeperm {Username|Permission]",
+      "text":"Removes permissions from a given user."
+   },
+   {
+      "name":"listusers",
+      "usage":"/listusers",
+      "text":" Lists all users in the server's database. This command takes no arguments."
+   },
+   {
+      "name":"logout",
+      "usage":"/logout",
+      "text":"Logs the caller out from their moderator user. This command takes no arguments."
+   },
+   {
+      "name":"pos",
+      "usage":"/pos [Position]",
+      "text":"Changes the client's position."
+   },
+   {
+      "name":"g",
+      "usage":"/g [Message]",
+      "text":"Sends a global message (i.e., all clients in the server will be able to see it)."
+   },
+   {
+      "name":"need",
+      "usage":"/need [Message]",
+      "text":"A global message expressing that the client needs something (generally: players for something)."
+   },
+   {
+      "name":"coinflip",
+      "usage":"/coinflip",
+      "text":"Flips a coin, returning heads or tails. This command takes no arguments."
+   },
+   {
+      "name":"roll",
+      "usage":"/roll [Faces|Dice]",
+      "text":"Rools dice and sends the results to the area. The first argument is the amount of faces each die should have. The second argument is the amount of dice that should be rolled. Both arguments are optional."
+   },
+   {
+      "name":"rollp",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"Rolls dice, but sends the results in private to the roller. The first argument is the amount of faces each die should have. The second argument is the amount of dice that should be rolled. Both arguments are optional."
+   },
+   {
+      "name":"doc",
+      "usage":"/doc [Link/Text]",
+      "text":"Sets the `/doc` to a custom text."
+   },
+   {
+      "name":"cleardoc",
+      "usage":"/cleardoc",
+      "text":"Sets the `/doc` to `No document.`. This command takes no arguments."
+   },
+   {
+      "name":"cm",
+      "usage":"/cm *[ID]",
+      "text":"Promotes a client to CM status. If called with a user ID as an argument, and the caller is a CM, promotes the target client to CM status."
+   },
+   {
+      "name":"uncm",
+      "usage":"/uncm",
+      "text":"Removes the CM status from the caller. This command takes no arguments."
+   },
+   {
+      "name":"invite",
+      "usage":"/invite [ID]",
+      "text":"Invites a client to the area."
+   },
+   {
+      "name":"uninvite",
+      "usage":"/uninvite [ID]",
+      "text":"Uninvites a client to the area."
+   },
+   {
+      "name":"lock",
+      "usage":"/lock",
+      "text":"Locks the area. This command takes no arguments."
+   },
+   {
+      "name":"area_lock",
+      "usage":"/area_lock",
+      "text":"Locks the area. This command takes no arguments."
+   },
+   {
+      "name":"spectatable",
+      "usage":"/spectatable",
+      "text":"Sets the area to spectatable. This command takes no arguments."
+   },
+   {
+      "name":"area_spectate",
+      "usage":"/area_spectate",
+      "text":"Sets the area to spectatable. This command takes no arguments."
+   },
+   {
+      "name":"unlock",
+      "usage":"/unlock",
+      "text":"Unlocks the area. This command takes no arguments."
+   },
+   {
+      "name":"area_unlock",
+      "usage":"/area_unlock",
+      "text":"Unlocks the area. This command takes no arguments."
+   },
+   {
+      "name":"timer",
+      "usage":"/timer *[TimerID|Duration]",
+      "text":"Gets or sets the global or one of the area-specific timers. If called without arguments, sends an out-of-character message listing the statuses of both the global timer and the area-specific timers. If called with one argument, and that argument is between `0` and `4` (inclusive on both ends), sends an out-of-character message about the status of the given timer, where `0` is the global timer, and the remaining numbers are the first, second, third and fourth timers in the current area."
+   },
+   {
+      "name":"play",
+      "usage":"/play [Song]",
+      "text":"Plays music in the area. Can play either a local file or a URL."
+   },
+   {
+      "name":"areakick",
+      "usage":"/areakick [ID]",
+      "text":"Kicks a client from the area, moving them back to the default area."
+   },
+   {
+      "name":"area_kick",
+      "usage":"/area_kick [ID]",
+      "text":"Kicks a client from the area, moving them back to the default area."
+   },
+   {
+      "name":"randomchar",
+      "usage":"/randomchar",
+      "text":"Picks a new random character for the client. This command takes no arguments."
+   },
+   {
+      "name":"switch",
+      "usage":"/switch [CharacterID]",
+      "text":"Switches to a different character based on character ID."
+   },
+   {
+      "name":"toggleglobal",
+      "usage":"/toggleglobal",
+      "text":"Toggles whether the client will ignore global messages or not."
+   },
+   {
+      "name":"mods",
+      "usage":"/mods",
+      "text":"Lists the currently logged-in moderators on the server."
+   },
+   {
+      "name":"commands",
+      "usage":"/commands",
+      "text":"Lists all the commands that the caller client has the permissions to use. This command takes no arguments."
+   },
+   {
+      "name":"status",
+      "usage":"/status [Status]",
+      "text":"Changes the status of the current area."
+   },
+   {
+      "name":"forcepos",
+      "usage":"/forcepos [ID|Position]",
+      "text":"Forces a client, or all clients in the area, to a specific position. The first argument is the client's ID or * for all client. The second argument is the position to force the clients to."
+   },
+   {
+      "name":"currentmusic",
+      "usage":"/currentmusic",
+      "text":"Returns the currently playing music in the area, and who played it. This command takes no arguments."
+   },
+   {
+      "name":"pm",
+      "usage":"/pm [ID|Message]",
+      "text":"Sends a direct message to another client on the server based on ID."
+   },
+   {
+      "name":"evidence_mod",
+      "usage":"/evidence_mod [EvidenceMod]",
+      "text":"Changes the evidence mod in the area."
+   },
+   {
+      "name":"motd",
+      "usage":"/motd *[Message]",
+      "text":"Gets or sets the server's Message Of The Day. If called without argument, gets the MOTD. If it has a message, sets the message as the MOTD."
+   },
+   {
+      "name":"announce",
+      "usage":"/announce [Message]",
+      "text":"Sends out a decorated global message, for announcements."
+   },
+   {
+      "name":"m",
+      "usage":"/m [Message]",
+      "text":"Sends a message in the server-wide, moderator only chat."
+   },
+   {
+      "name":"gm",
+      "usage":"/gm [Message]",
+      "text":"Sends out a global message that is marked with an `[M]` to mean it is coming from a moderator."
+   },
+   {
+      "name":"mute",
+      "usage":"/mute [ClientID]",
+      "text":"Mutes a client."
+   },
+   {
+      "name":"unmute",
+      "usage":"/unmute [ClientID]",
+      "text":"Removes the muted status from a client."
+   },
+   {
+      "name":"bans",
+      "usage":"/bans",
+      "text":"Lists the last five bans made on the server. This command takes no arguments."
+   },
+   {
+      "name":"unban",
+      "usage":"/unban [BanID]",
+      "text":"Removes a ban from the database."
+   },
+   {
+      "name":"removeuser",
+      "usage":"/removeuser [Username]",
+      "text":"Removes a user from the moderators in `advanced` authorisation type."
+   },
+   {
+      "name":"subtheme",
+      "usage":"/subtheme [Theme]",
+      "text":"Changes the subtheme of the clients in the current area."
+   },
+   {
+      "name":"about",
+      "usage":"/about",
+      "text":"Gives a very brief description of Akashi. This command takes no arguments."
+   },
+   {
+      "name":"evidence_swap",
+      "usage":"/foo [EvidenceID|EvidenceID]",
+      "text":"Changes position of two pieces of evidence in the area."
+   },
+   {
+      "name":"notecard",
+      "usage":"/notecard [Message]",
+      "text":"Writes a note card in the current area. he note card is not readable until all note cards in the area are revealed by a CM. A message will appear to all clients in the area indicating that a note card has been written."
+   },
+   {
+      "name":"notecardreveal",
+      "usage":"/notecardreveal",
+      "text":"Reveals all note cards in the current area. This command takes no arguments."
+   },
+   {
+      "name":"notecard_reveal",
+      "usage":"/notecard_reveal",
+      "text":"Reveals all note cards in the current area. This command takes no arguments."
+   },
+   {
+      "name":"notecardclear",
+      "usage":"/notecardclear",
+      "text":"Erases the client's note card from the area's list of cards. A message will appear to all clients in the area indicating that a note card has been erased. This command takes no arguments."
+   },
+   {
+      "name":"notecard_clear",
+      "usage":"/notecard_clear",
+      "text":"Erases the client's note card from the area's list of cards. A message will appear to all clients in the area indicating that a note card has been erased. This command takes no arguments."
+   },
+   {
+      "name":"8ball",
+      "usage":"/8ball [Question]",
+      "text":"Randomly selects an answer from 8ball.txt to a question."
+   },
+   {
+      "name":"lm",
+      "usage":"/lm [Message]",
+      "text":"Sends out a local message that is marked with an `[M]` to mean it is coming from a moderator."
+   },
+   {
+      "name":"judgelog",
+      "usage":"/judgelog",
+      "text":"ends an out-of-character message with the judgelog of an area. This command takes no arguments."
+   },
+   {
+      "name":"allowblankposting",
+      "usage":"allowblankposting",
+      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense this also allows you to disable blankposting."
+   },
+   {
+      "name":"allow_blankposting",
+      "usage":"/allow_blankposting",
+      "text":"Toggle whether or not in-character messages purely consisting of spaces are allowed. Takes no arguments. Against all common sense this also allows you to disable blankposting."
+   },
+   {
+      "name":"gimp",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"ungimp",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"baninfo",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"testify",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"testimony",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"examine",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"pause",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"delete",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"update",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"add",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"reload",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"disemvovel",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"undisemvovel",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"shake",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"unshake",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"forceimmediate",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"force_noint_pres",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"allowiniswap",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"allow_iniswap",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"afk",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"savetestimony",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"loadtestimony",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"permitsaving",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"mutepm",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"oocmute",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"ooc_mute",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"oocunmute",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"ooc_unmute",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"blockwtce",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"block_wtce",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"unblockwtce",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"unlock_wtce",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"blockdj",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"block_dj",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"unblockdj",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"unblock_dj",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"charcurse",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"uncharcurse",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"charselect",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"togglemusic",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"a",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"s",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"kickuid",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"kick_uid",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"firstperson",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"updateban",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"update_ban",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"changepass",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"ignorebglist",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"ignore_bglist",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"notice",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"noticeg",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"togglejukebox",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   },
+   {
+      "name":"help",
+      "usage":"/foo <bar> [baz|qux]",
+      "text":"A sample explanation."
+   }
 ]

--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "foo",
+    "usage": "/foo <bar> [baz|qux]",
+    "text": "A sample explanation."
+  }
+]

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1604,6 +1604,14 @@ class AOClient : public QObject {
      * @iscommand
      */
     void cmdUnCharCurse(int argc, QStringList argv);
+
+    /**
+     * @brief Forces a client into the charselect screen.
+     *
+     * @details The only argument is the **target's ID** whom the client wants to force into charselect.
+     *
+     * @iscommand
+     */
     void cmdCharSelect(int argc, QStringList argv);
 
     /**
@@ -1818,7 +1826,7 @@ class AOClient : public QObject {
     void cmdToggleMusic(int argc, QStringList argv);
 
     /**
-     * @brief cmdToggleJukebox Toggles jukebox status in the current area.
+     * @brief Toggles jukebox status in the current area.
      *
      * @details No arguments.
      */

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1001,6 +1001,13 @@ class AOClient : public QObject {
      *
      * @iscommand
      */
+    void cmdCommands(int argc, QStringList argv);
+
+    /**
+     * @brief Lists help information to the command requested. Includes syntax and brief explanation.
+     *
+     * @details Takes the command name as an argument.
+     */
     void cmdHelp(int argc, QStringList argv);
 
     /**
@@ -2048,7 +2055,7 @@ class AOClient : public QObject {
         {"switch",             {ACLFlags.value("NONE"),         1, &AOClient::cmdSwitch}},
         {"toggleglobal",       {ACLFlags.value("NONE"),         0, &AOClient::cmdToggleGlobal}},
         {"mods",               {ACLFlags.value("NONE"),         0, &AOClient::cmdMods}},
-        {"help",               {ACLFlags.value("NONE"),         0, &AOClient::cmdHelp}},
+        {"commands",           {ACLFlags.value("NONE"),         0, &AOClient::cmdCommands}},
         {"status",             {ACLFlags.value("NONE"),         1, &AOClient::cmdStatus}},
         {"forcepos",           {ACLFlags.value("CM"),           2, &AOClient::cmdForcePos}},
         {"currentmusic",       {ACLFlags.value("NONE"),         0, &AOClient::cmdCurrentMusic}},
@@ -2130,6 +2137,7 @@ class AOClient : public QObject {
         {"notice",             {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNotice}},
         {"noticeg",            {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNoticeGlobal}},
         {"togglejukebox",      {ACLFlags.value("None"),         0, &AOClient::cmdToggleJukebox}},
+        {"help",               {ACLFlags.value("NONE"),         1, &AOClient::cmdHelp}}
     };
 
     /**

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -82,7 +82,7 @@ class ConfigManager {
      *
      * @return See short description.
      */
-    static void loadcommandHelp();
+    static void loadCommandHelp();
 
     /**
      * @brief Returns the duration of a song in the songlist.

--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -78,6 +78,13 @@ class ConfigManager {
     static QStringList musiclist();
 
     /**
+     * @brief Loads help information into m_help_information.
+     *
+     * @return See short description.
+     */
+    static void loadcommandHelp();
+
+    /**
      * @brief Returns the duration of a song in the songlist.
      * @param The name of the song where duration is requested
      * @return The duration of the song
@@ -423,6 +430,22 @@ class ConfigManager {
     static qint64 uptime();
 
     /**
+     * @brief A struct that contains the help information for a command.
+     *        It's split in the syntax and the explanation text.
+     */
+     struct help {
+        QString usage;
+        QString text;
+    };
+
+    /**
+     * @brief Returns a struct with the help information of the command.
+     *
+     * @return See short description.
+     */
+    static help commandHelp(QString f_command_name);
+
+    /**
      * @brief Sets the server's authorization type.
      *
      * @param f_auth The auth type to set.
@@ -499,6 +522,11 @@ private:
      * @brief Contains the musiclist with time durations.
      */
     static QHash<QString,float>* m_musicList;
+
+    /**
+     * @brief QHash containing the help information for all commands registered to the server.
+     */
+    static QHash<QString,help>* m_commands_help;
 
     /**
      * @brief Returns a stringlist with the contents of a .txt file from config/text/.

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -200,6 +200,7 @@ void AOClient::handleCommand(QString command, int argc, QStringList argv)
 
     if (argc < l_info.minArgs) {
         sendServerMessage("Invalid command syntax.");
+        sendServerMessage("The expected syntax for this command is: \n" + ConfigManager::commandHelp(command).usage);
         return;
     }
 

--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -149,7 +149,7 @@ void AOClient::cmdMods(int argc, QStringList argv)
     sendServerMessage(l_entries.join("\n"));
 }
 
-void AOClient::cmdHelp(int argc, QStringList argv)
+void AOClient::cmdCommands(int argc, QStringList argv)
 {
     Q_UNUSED(argc);
     Q_UNUSED(argv);
@@ -164,6 +164,17 @@ void AOClient::cmdHelp(int argc, QStringList argv)
         }
     }
     sendServerMessage(l_entries.join("\n"));
+}
+
+void AOClient::cmdHelp(int argc, QStringList argv)
+{
+    if(argc > 1) {
+        sendServerMessage("Too many arguments. Please only use the command name.");
+    }
+
+    QString l_command_name = argv[0];
+    ConfigManager::help l_command_info = ConfigManager::commandHelp(l_command_name);
+    sendServerMessage("==Help==\n" +l_command_info.usage + "\n" + l_command_info.text);
 }
 
 void AOClient::cmdMOTD(int argc, QStringList argv)

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -175,7 +175,7 @@ QStringList ConfigManager::musiclist()
     return l_musiclist;
 }
 
-void ConfigManager::loadcommandHelp()
+void ConfigManager::loadCommandHelp()
 {
     QFile l_music_json("config/text/commandhelp.json");
     l_music_json.open(QIODevice::ReadOnly | QIODevice::Text);
@@ -183,7 +183,7 @@ void ConfigManager::loadcommandHelp()
     QJsonParseError l_error;
     QJsonDocument l_music_list_json = QJsonDocument::fromJson(l_music_json.readAll(), &l_error);
     if (!(l_error.error == QJsonParseError::NoError)) { //Non-Terminating error.
-        qWarning() << "Unable to help information. The following error was encounted : " + l_error.errorString();
+        qWarning() << "Unable to load help information. The following error occurred: " + l_error.errorString();
     }
 
     // Akashi expects the helpfile to contain multiple entires, so it always checks for an array first.
@@ -202,7 +202,6 @@ void ConfigManager::loadcommandHelp()
             l_help_information.text = l_text;
 
             m_commands_help->insert(l_name,l_help_information);
-            qDebug() << commandHelp("foo").text;
         }
     }
 }

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -98,7 +98,7 @@ void Server::start()
     }
 
     //Loads the command help information. This is not stored inside the server.
-    ConfigManager::loadcommandHelp();
+    ConfigManager::loadCommandHelp();
 
     //Rate-Limiter for IC-Chat
     connect(&next_message_timer, SIGNAL(timeout()), this, SLOT(allowMessage()));

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -97,6 +97,9 @@ void Server::start()
                 this, QOverload<AOPacket,int>::of(&Server::broadcast));
     }
 
+    //Loads the command help information. This is not stored inside the server.
+    ConfigManager::loadcommandHelp();
+
     //Rate-Limiter for IC-Chat
     connect(&next_message_timer, SIGNAL(timeout()), this, SLOT(allowMessage()));
 }


### PR DESCRIPTION
Current, you are on your own when you want to know why your command fails. 
This PR adds a help information loader that allows users to get help texts right in the client + expands the general "Syntax error" messages into something helpful by providing you the correct syntax.

closes #59 