### PR TITLE
Fix database permission error when database is first created

### DIFF
--- a/core/src/db_manager.cpp
+++ b/core/src/db_manager.cpp
@@ -22,8 +22,14 @@ DBManager::DBManager() :
 {
     const QString db_filename = "config/akashi.db";
     QFileInfo db_info(db_filename);
-    if(!db_info.isReadable() || !db_info.isWritable()) 
-        qCritical() << tr("Database Error: Missing permissions. Check if \"%1\" is writable.").arg(db_filename);
+    if (!db_info.exists()) {
+        qWarning().noquote() << tr("Database Info: Database not found. Attempting to create new database.");
+    }
+    else {
+        //We should only check if a file is readable/writeable when it actually exists.
+        if(!db_info.isReadable() || !db_info.isWritable())
+            qCritical() << tr("Database Error: Missing permissions. Check if \"%1\" is writable.").arg(db_filename);
+    }
 
     db = QSqlDatabase::addDatabase(DRIVER);
     db.setDatabaseName("config/akashi.db");


### PR DESCRIPTION
It was apparently perfectly acceptable to some that it shows an error when the file did not even have a chance to exist.