### PR TITLE
Make it easier to reuse code targeting specific user groups

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -307,6 +307,16 @@ class AOClient : public QObject {
      */
     bool m_is_logging_in = false;
 
+    /**
+     * @brief Checks if the client would be authorised to something based on its necessary permissions.
+     *
+     * @param acl_mask The permissions bitflag that the client's own permissions should be checked against.
+     *
+     * @return True if the client's permissions are high enough for `acl_mask`, or higher than it.
+     * False if the client is missing some permissions.
+     */
+    bool checkAuth(unsigned long long acl_mask);
+
   public slots:
     /**
      * @brief A slot for when the client disconnects from the server.
@@ -432,16 +442,6 @@ class AOClient : public QObject {
      * @param message The text of the message to send.
      */
     void sendServerBroadcast(QString message);
-
-    /**
-     * @brief Checks if the client would be authorised to something based on its necessary permissions.
-     *
-     * @param acl_mask The permissions bitflag that the client's own permissions should be checked against.
-     *
-     * @return True if the client's permissions are high enough for `acl_mask`, or higher than it.
-     * False if the client is missing some permissions.
-     */
-    bool checkAuth(unsigned long long acl_mask);
 
     /**
       * @name Packet headers

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -79,7 +79,8 @@ class Server : public QObject {
      * @brief Enum to specifc different targets to send altered packets to a specific usergroup.
      */
     enum class TARGET_TYPE {
-        AUTHENTICATED
+        AUTHENTICATED,
+        MODCHAT
     };
     Q_ENUM(TARGET_TYPE)
 
@@ -139,9 +140,21 @@ class Server : public QObject {
 
     /**
      * @brief Sends a packet to clients, sends an altered packet to a specific usergroup.
+     *
      * @param The packet to send to the clients.
+     *
+     * @param ENUM to determine the targets of the altered packet.
+     */
+    void broadcast(AOPacket packet, TARGET_TYPE target);
+
+    /**
+     * @brief Sends a packet to clients, sends an altered packet to a specific usergroup.
+     *
+     * @param The packet to send to the clients.
+     *
      * @param The altered packet to send to the other clients.
-     * @param tENUM to determine the targets of the altered packet.
+     *
+     * @param ENUM to determine the targets of the altered packet.
      */
     void broadcast(AOPacket packet, AOPacket other_packet, enum TARGET_TYPE target);
 

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -80,7 +80,8 @@ class Server : public QObject {
      */
     enum class TARGET_TYPE {
         AUTHENTICATED,
-        MODCHAT
+        MODCHAT,
+        ADVERT
     };
     Q_ENUM(TARGET_TYPE)
 

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -76,6 +76,14 @@ class Server : public QObject {
     void start();
 
     /**
+     * @brief Enum to specifc different targets to send altered packets to a specific usergroup.
+     */
+    enum class TARGET_TYPE {
+        AUTHENTICATED
+    };
+    Q_ENUM(TARGET_TYPE)
+
+    /**
      * @brief Gets a pointer to a client by IPID.
      *
      * @param ipid The IPID to look for.
@@ -128,6 +136,14 @@ class Server : public QObject {
      * @param packet The packet to send to the clients.
      */
     void broadcast(AOPacket packet);
+
+    /**
+     * @brief Sends a packet to clients, sends an altered packet to a specific usergroup.
+     * @param The packet to send to the clients.
+     * @param The altered packet to send to the other clients.
+     * @param tENUM to determine the targets of the altered packet.
+     */
+    void broadcast(AOPacket packet, AOPacket other_packet, enum TARGET_TYPE target);
 
     /**
      * @brief Returns the character's character ID (= their index in the character list).

--- a/core/src/commands/messaging.cpp
+++ b/core/src/commands/messaging.cpp
@@ -173,11 +173,7 @@ void AOClient::cmdM(int argc, QStringList argv)
 
     QString l_sender_name = m_ooc_name;
     QString l_sender_message = argv.join(" ");
-    for (AOClient* client : qAsConst(server->m_clients)) {
-        if (client->checkAuth(ACLFlags.value("MODCHAT")))
-            client->sendPacket("CT", {"[M]" + l_sender_name, l_sender_message});
-    }
-    return;
+    server->broadcast(AOPacket("CT", {"[M]" + l_sender_name, l_sender_message}), Server::TARGET_TYPE::MODCHAT);
 }
 
 void AOClient::cmdGM(int argc, QStringList argv)
@@ -187,11 +183,7 @@ void AOClient::cmdGM(int argc, QStringList argv)
     QString l_sender_name = m_ooc_name;
     QString l_sender_area = server->m_area_names.value(m_current_area);
     QString l_sender_message = argv.join(" ");
-    for (AOClient* l_client : qAsConst(server->m_clients)) {
-        if (l_client->m_global_enabled) {
-            l_client->sendPacket("CT", {"[G][" + l_sender_area + "]" + "["+ l_sender_name+"][M]", l_sender_message});
-        }
-    }
+    server->broadcast(AOPacket("CT", {"[G][" + l_sender_area + "]" + "["+ l_sender_name+"][M]", l_sender_message}),Server::TARGET_TYPE::MODCHAT);
 }
 
 void AOClient::cmdLM(int argc, QStringList argv)

--- a/core/src/commands/messaging.cpp
+++ b/core/src/commands/messaging.cpp
@@ -71,6 +71,7 @@ void AOClient::cmdG(int argc, QStringList argv)
     QString l_sender_name = m_ooc_name;
     QString l_sender_area = server->m_area_names.value(m_current_area);
     QString l_sender_message = argv.join(" ");
+    //Slightly better readability
     AOPacket l_packet = AOPacket("CT", {"[G][" + m_ipid + "][" + l_sender_area + "]" + l_sender_name, l_sender_message});
     AOPacket l_other_packet = AOPacket("CT", {"[G][" + l_sender_area + "]" + l_sender_name, l_sender_message});
     server->broadcast(l_packet, l_other_packet, Server::TARGET_TYPE::AUTHENTICATED);
@@ -83,11 +84,7 @@ void AOClient::cmdNeed(int argc, QStringList argv)
 
     QString l_sender_area = server->m_area_names.value(m_current_area);
     QString l_sender_message = argv.join(" ");
-    for (AOClient* l_client : qAsConst(server->m_clients)) {
-        if (l_client->m_advert_enabled) {
-            l_client->sendServerMessage({"=== Advert ===\n[" + l_sender_area + "] needs " + l_sender_message+ "."});
-        }
-    }
+    server->broadcast(AOPacket("CT",{"=== Advert ===\n[" + l_sender_area + "] needs " + l_sender_message+ "."}),Server::TARGET_TYPE::ADVERT);
 }
 
 void AOClient::cmdSwitch(int argc, QStringList argv)

--- a/core/src/commands/messaging.cpp
+++ b/core/src/commands/messaging.cpp
@@ -71,10 +71,9 @@ void AOClient::cmdG(int argc, QStringList argv)
     QString l_sender_name = m_ooc_name;
     QString l_sender_area = server->m_area_names.value(m_current_area);
     QString l_sender_message = argv.join(" ");
-    for (AOClient* l_client : qAsConst(server->m_clients)) {
-        if (l_client->m_global_enabled)
-            l_client->sendPacket("CT", {"[G][" + l_sender_area + "]" + l_sender_name, l_sender_message});
-    }
+    AOPacket l_packet = AOPacket("CT", {"[G][" + m_ipid + "][" + l_sender_area + "]" + l_sender_name, l_sender_message});
+    AOPacket l_other_packet = AOPacket("CT", {"[G][" + l_sender_area + "]" + l_sender_name, l_sender_message});
+    server->broadcast(l_packet, l_other_packet, Server::TARGET_TYPE::AUTHENTICATED);
     return;
 }
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -215,6 +215,21 @@ void Server::broadcast(AOPacket packet)
     }
 }
 
+void Server::broadcast(AOPacket packet, TARGET_TYPE target)
+{
+    switch (target) {
+    case TARGET_TYPE::MODCHAT:
+        for (AOClient* l_client : qAsConst(m_clients)) {
+            if (l_client->checkAuth(l_client->ACLFlags.value("MODCHAT"))) {
+                l_client->sendPacket(packet);
+            }
+        }
+    default:
+        //Unimplemented, so not handled.
+        break;
+    }
+}
+
 void Server::broadcast(AOPacket packet, AOPacket other_packet, TARGET_TYPE target)
 {
     switch (target) {
@@ -227,6 +242,9 @@ void Server::broadcast(AOPacket packet, AOPacket other_packet, TARGET_TYPE targe
                 client->sendPacket(packet);
             }
         }
+    default:
+        //Unimplemented, so not handled.
+        break;
     }
 }
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -215,6 +215,21 @@ void Server::broadcast(AOPacket packet)
     }
 }
 
+void Server::broadcast(AOPacket packet, AOPacket other_packet, TARGET_TYPE target)
+{
+    switch (target) {
+    case TARGET_TYPE::AUTHENTICATED:
+        for (AOClient* client : qAsConst(m_clients)){
+            if (client->m_authenticated) {
+                client->sendPacket(other_packet);
+            }
+            else {
+                client->sendPacket(packet);
+            }
+        }
+    }
+}
+
 QList<AOClient*> Server::getClientsByIpid(QString ipid)
 {
     QList<AOClient*> return_clients;

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -217,16 +217,21 @@ void Server::broadcast(AOPacket packet)
 
 void Server::broadcast(AOPacket packet, TARGET_TYPE target)
 {
-    switch (target) {
-    case TARGET_TYPE::MODCHAT:
-        for (AOClient* l_client : qAsConst(m_clients)) {
+    for (AOClient* l_client : qAsConst(m_clients)) {
+        switch (target) {
+        case TARGET_TYPE::MODCHAT:
             if (l_client->checkAuth(l_client->ACLFlags.value("MODCHAT"))) {
                 l_client->sendPacket(packet);
             }
+            break;
+        case TARGET_TYPE::ADVERT:
+            if (l_client->m_advert_enabled) {
+                l_client->sendPacket(packet);
+            }
+            break;
+        default:
+            break;
         }
-    default:
-        //Unimplemented, so not handled.
-        break;
     }
 }
 

--- a/core/src/testimony_recorder.cpp
+++ b/core/src/testimony_recorder.cpp
@@ -43,10 +43,10 @@ void AOClient::addStatement(QStringList packet)
                 area->addStatement(c_statement, packet);
                 area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
             }
-            else {
-                sendServerMessage("Unable to add more statements. The maximum amount of statements has been reached.");
-                area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
-            }
+        else {
+            sendServerMessage("Unable to add more statements. The maximum amount of statements has been reached.");
+            area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
+        }
     }
 }
 


### PR DESCRIPTION
This also has an example that makes moderation easier by sending mods an altered version of the global message to include a user IPID.