### PR TITLE
Stfu, asset url is valid now

### DIFF
--- a/bin/config_sample/config.ini
+++ b/bin/config_sample/config.ini
@@ -62,7 +62,7 @@ message_floodguard=250
 afk_timeout = 300
 
 ; The URL of the server's remote repository, sent to the client during their initial handshake. Used by WebAO users for custom content.
-asset_url=
+asset_url=http://attorneyoffline.de/base/
 
 [ModernAdvertiser]
 ; Options for the HTTP based Masterserver.


### PR DESCRIPTION
Add Vanilla content host to the sample config so Akashi stops crying about it each time a client even dares to connect.