### PR TITLE
Add Area Messages

### DIFF
--- a/bin/config_sample/text/commandhelp.json
+++ b/bin/config_sample/text/commandhelp.json
@@ -633,5 +633,20 @@
       "name":"clearcm",
       "usage":"/clearcm",
       "text":"Removes all CMs from the current area. This command takes no arguments."
+   },
+   {
+      "name":"togglemessage",
+      "usage":"/togglemessage",
+      "text":"Toggles wether the client shows the area message when joining the current area."
+   },
+   {
+      "name":"clearmessage",
+      "usage":"/clearmessage",
+      "text":"Clears the areas message and disables automatic sending."
+   },
+   {
+      "name":"areamessage",
+      "usage":"/areamessage",
+      "text":"Returns the area message in OOC. If text is entered it updates the current area message."
    }
 ]

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -984,6 +984,33 @@ class AOClient : public QObject {
      */
     void cmdIgnoreBgList(int argc, QStringList argv);
 
+    /**
+     * @brief Returns the area message in OOC. Double to set the current area message.
+     *
+     * @details See short description.
+     *
+     * @iscommand
+     */
+    void cmdAreaMessage(int argc, QStringList argv);
+
+    /**
+     * @brief Clears the areas message and disables automatic sending.
+     *
+     * @details No arguments.
+     *
+     * @iscommand
+     */
+    void cmdClearAreaMessage(int argc, QStringList argv);
+
+    /**
+     * @brief Toggles wether the client shows the area message when joining the current area.
+     *
+     * @details No arguments.
+     *
+     * @iscommand
+     */
+    void cmdToggleAreaMessageOnJoin(int argc, QStringList argv);
+
     ///@}
 
     /**
@@ -2155,7 +2182,10 @@ class AOClient : public QObject {
         {"noticeg",            {ACLFlags.value("SEND_NOTICE"),  1, &AOClient::cmdNoticeGlobal}},
         {"togglejukebox",      {ACLFlags.value("None"),         0, &AOClient::cmdToggleJukebox}},
         {"help",               {ACLFlags.value("NONE"),         1, &AOClient::cmdHelp}},
-        {"clearcm",            {ACLFlags.value("KICK"),         0, &AOClient::cmdClearCM}}
+        {"clearcm",            {ACLFlags.value("KICK"),         0, &AOClient::cmdClearCM}},
+        {"togglemessage",      {ACLFlags.value("CM"),           0, &AOClient::cmdToggleAreaMessageOnJoin}},
+        {"clearmessage",       {ACLFlags.value("CM"),           0, &AOClient::cmdClearAreaMessage}},
+        {"areamessage",        {ACLFlags.value("CM"),           0, &AOClient::cmdAreaMessage}}
     };
 
     /**

--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -542,6 +542,29 @@ class AreaData : public QObject {
     void changeDoc(const QString& f_newDoc_r);
 
     /**
+     * @brief Returns the message of the area.
+     *
+     * @return See short description.
+     *
+     * @see #m_area_message
+     */
+    QString areaMessage() const;
+
+    /**
+     * @brief Returns if the flavour text is send by joining the area.
+     *
+     * @return See short description.
+     */
+    bool sendAreaMessageOnJoin() const;
+
+    /**
+     * @brief Changes the area message in the area.
+     *
+     * @param f_newFlacour_r The new flavour text.
+     */
+    void changeAreaMessage(const QString& f_newMessage_r);
+
+    /**
      * @brief Returns the value of the Confidence bar for the defence's side.
      *
      * @return The value of the Confidence bar in units of 10%.
@@ -807,6 +830,11 @@ class AreaData : public QObject {
     void toggleIgnoreBgList();
 
     /**
+     * @brief Toggles wether the area message is send on joining the area.
+     */
+    void toggleAreaMessageJoin();
+
+    /**
      * @brief Toggles wether the jukebox is enabled or not.
      */
     void toggleJukebox();
@@ -816,7 +844,7 @@ class AreaData : public QObject {
      */
     QString addJukeboxSong(QString f_song);
 
-  public slots:
+public slots:
 
     /**
      * @brief Plays a random song from the jukebox. Plays the same if only one is left.
@@ -933,6 +961,14 @@ private:
     QString m_document;
 
     /**
+     * @brief The message of the area.
+     *
+     * @details The area mnessage has multiple purposes. It can be used to provide general information for
+     * RP or guidance for players joining the area. Unlike document it can send on area join.
+     */
+    QString m_area_message;
+
+    /**
      * @brief The Confidence Gauge's value for the Defence side.
      *
      * @details Unit is 10%, and the values range from 0 (= 0%) to 10 (= 100%).
@@ -1018,6 +1054,11 @@ private:
      * @brief Whether or not to ignore the server defined background list. If true, any background can be set in an area.
      */
     bool m_ignoreBgList;
+
+    /**
+     * @brief Wether or not the area message is send on joining it.
+     */
+    bool m_send_area_message;
 
     // Jukebox specific members
     /**

--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -551,7 +551,7 @@ class AreaData : public QObject {
     QString areaMessage() const;
 
     /**
-     * @brief Returns if the flavour text is send by joining the area.
+     * @brief Returns if the area's message should be sent when a user joins the area.
      *
      * @return See short description.
      */
@@ -560,7 +560,7 @@ class AreaData : public QObject {
     /**
      * @brief Changes the area message in the area.
      *
-     * @param f_newFlacour_r The new flavour text.
+     * @param f_newMessage_r The new message.
      */
     void changeAreaMessage(const QString& f_newMessage_r);
 
@@ -830,7 +830,7 @@ class AreaData : public QObject {
     void toggleIgnoreBgList();
 
     /**
-     * @brief Toggles wether the area message is send on joining the area.
+     * @brief Toggles whether the area message is sent upon joining the area.
      */
     void toggleAreaMessageJoin();
 
@@ -963,8 +963,8 @@ private:
     /**
      * @brief The message of the area.
      *
-     * @details The area mnessage has multiple purposes. It can be used to provide general information for
-     * RP or guidance for players joining the area. Unlike document it can send on area join.
+     * @details The area message has multiple purposes. It can be used to provide general information for
+     * RP or guidance for players joining the area. Unlike document it can be sent on area join. Like a MOTD, but for the area.
      */
     QString m_area_message;
 
@@ -1056,7 +1056,7 @@ private:
     bool m_ignoreBgList;
 
     /**
-     * @brief Wether or not the area message is send on joining it.
+     * @brief Whether or not the area message is sent upon area join.
      */
     bool m_send_area_message;
 

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -150,6 +150,9 @@ void AOClient::changeArea(int new_area)
         }
     }
     sendServerMessage("You moved to area " + server->m_area_names[m_current_area]);
+    if (server->m_areas[m_current_area]->sendAreaMessageOnJoin())
+        sendServerMessage(server->m_areas[m_current_area]->areaMessage());
+
     if (server->m_areas[m_current_area]->lockStatus() == AreaData::LockStatus::SPECTATABLE)
         sendServerMessage("Area " + server->m_area_names[m_current_area] + " is spectate-only; to chat IC you will need to be invited by the CM.");
 }

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -26,11 +26,13 @@ AreaData::AreaData(QString p_name, int p_index) :
     m_status(IDLE),
     m_locked(FREE),
     m_document("No document."),
+    m_area_message("No flavour text."),
     m_defHP(10),
     m_proHP(10),
     m_statement(0),
     m_judgelog(),
-    m_lastICMessage()
+    m_lastICMessage(),
+    m_send_area_message(false)
 {
     QStringList name_split = p_name.split(":");
     name_split.removeFirst();
@@ -479,6 +481,24 @@ void AreaData::changeDoc(const QString &f_newDoc_r)
     m_document = f_newDoc_r;
 }
 
+QString AreaData::areaMessage() const
+{
+    return m_area_message;
+}
+
+bool AreaData::sendAreaMessageOnJoin() const
+{
+    return m_send_area_message;
+}
+
+void AreaData::changeAreaMessage(const QString& f_newMessage_r)
+{
+    if(f_newMessage_r.isEmpty())
+        m_area_message = "No flavour text.";
+    else
+        m_area_message = f_newMessage_r;
+}
+
 bool AreaData::bgLocked() const
 {
     return m_bgLocked;
@@ -522,6 +542,11 @@ bool AreaData::ignoreBgList()
 void AreaData::toggleIgnoreBgList()
 {
     m_ignoreBgList = !m_ignoreBgList;
+}
+
+void AreaData::toggleAreaMessageJoin()
+{
+    m_send_area_message = !m_send_area_message;
 }
 
 void AreaData::toggleJukebox()

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -26,7 +26,7 @@ AreaData::AreaData(QString p_name, int p_index) :
     m_status(IDLE),
     m_locked(FREE),
     m_document("No document."),
-    m_area_message("No flavour text."),
+    m_area_message("No area message set."),
     m_defHP(10),
     m_proHP(10),
     m_statement(0),
@@ -494,7 +494,7 @@ bool AreaData::sendAreaMessageOnJoin() const
 void AreaData::changeAreaMessage(const QString& f_newMessage_r)
 {
     if(f_newMessage_r.isEmpty())
-        m_area_message = "No flavour text.";
+        m_area_message = "No area message set.";
     else
         m_area_message = f_newMessage_r;
 }

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -372,3 +372,39 @@ void AOClient::cmdIgnoreBgList(int argc, QStringList argv)
     QString l_state = l_area->ignoreBgList() ? "ignored." : "enforced.";
     sendServerMessage("BG list in this area is now " + l_state);
 }
+
+void AOClient::cmdAreaMessage(int argc, QStringList argv)
+{
+    AreaData* l_area = server->m_areas[m_current_area];
+    if (argc == 0) {
+        sendServerMessage(l_area->areaMessage());
+        return;
+    }
+
+    if (argc >= 1) {
+        l_area->changeAreaMessage(argv.join(" "));
+        sendServerMessage("Updated areas flavour text.");
+    }
+}
+
+void AOClient::cmdToggleAreaMessageOnJoin(int argc, QStringList argv)
+{
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
+    AreaData* l_area = server->m_areas[m_current_area];
+    l_area->toggleAreaMessageJoin();
+    QString l_state = l_area->sendAreaMessageOnJoin() ? "enabled." : "disabled.";
+    sendServerMessage("Sending flavour text on area join is now " +l_state);
+}
+
+void AOClient::cmdClearAreaMessage(int argc, QStringList argv)
+{
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+
+    AreaData* l_area = server->m_areas[m_current_area];
+    l_area->changeAreaMessage(QString{});
+    if (l_area->sendAreaMessageOnJoin()) //Turn off the automatic sending.
+        cmdToggleAreaMessageOnJoin(0,QStringList{}); //Dummy values.
+}

--- a/core/src/commands/area.cpp
+++ b/core/src/commands/area.cpp
@@ -383,7 +383,7 @@ void AOClient::cmdAreaMessage(int argc, QStringList argv)
 
     if (argc >= 1) {
         l_area->changeAreaMessage(argv.join(" "));
-        sendServerMessage("Updated areas flavour text.");
+        sendServerMessage("Updated this area's message.");
     }
 }
 
@@ -395,7 +395,7 @@ void AOClient::cmdToggleAreaMessageOnJoin(int argc, QStringList argv)
     AreaData* l_area = server->m_areas[m_current_area];
     l_area->toggleAreaMessageJoin();
     QString l_state = l_area->sendAreaMessageOnJoin() ? "enabled." : "disabled.";
-    sendServerMessage("Sending flavour text on area join is now " +l_state);
+    sendServerMessage("Sending message on area join is now " +l_state);
 }
 
 void AOClient::cmdClearAreaMessage(int argc, QStringList argv)


### PR DESCRIPTION
This allows CMs to set a message that can be sent when a client joins the area.
Useful for behaviour rules of specific areas, RP Guidelines, general info to the case, etc. Unlike Doc you can toggle if it sends or not.