### PR TITLE
Add ability for the musiclist entires to be an alias of another song.

### DIFF
--- a/core/include/config_manager.h
+++ b/core/include/config_manager.h
@@ -90,7 +90,7 @@ class ConfigManager {
      * @param The name of the song where duration is requested
      * @return The duration of the song
      */
-    static int songInformation(const QString& f_songName);
+    static QPair<QString, float> songInformation(const QString& f_songName);
 
     /**
      * @brief Returns the content of
@@ -535,7 +535,7 @@ private:
     /**
      * @brief Contains the musiclist with time durations.
      */
-    static QHash<QString,float>* m_musicList;
+    static QHash<QString,QPair<QString,float>>* m_musicList;
 
     /**
      * @brief QHash containing the help information for all commands registered to the server.

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -561,11 +561,14 @@ void AreaData::toggleJukebox()
 QString AreaData::addJukeboxSong(QString f_song)
 {
     if(!m_jukebox_queue.contains(f_song)) {
-            int l_song_duration = ConfigManager::songInformation(f_song);
-            if (l_song_duration > 0) {
+            //Retrieve song information.
+            QPair<QString,float> l_song = ConfigManager::songInformation(f_song);
+
+            if (l_song.second > 0) {
                 if (m_jukebox_queue.size() == 0) {
-                    emit playJukeboxSong(AOPacket("MC",{f_song,QString::number(-1)}), index());
-                    m_jukebox_timer->start(l_song_duration * 1000);
+
+                    emit playJukeboxSong(AOPacket("MC",{l_song.first,QString::number(-1)}), index());
+                    m_jukebox_timer->start(l_song.second * 1000);
                     setCurrentMusic(f_song);
                     setMusicPlayedBy("Jukebox");
                 }
@@ -584,14 +587,18 @@ void AreaData::switchJukeboxSong()
     QString l_song_name;
     if(m_jukebox_queue.size() == 1) {
         l_song_name = m_jukebox_queue[0];
-        emit playJukeboxSong(AOPacket("MC",{l_song_name,"-1"}), m_index);
-        m_jukebox_timer->start(ConfigManager::songInformation(l_song_name) * 1000);
+        QPair<QString,float> l_song = ConfigManager::songInformation(l_song_name);
+        emit playJukeboxSong(AOPacket("MC",{l_song.first,"-1"}), m_index);
+        m_jukebox_timer->start(l_song.second * 1000);
     }
     else {
         int l_random_index = QRandomGenerator::system()->bounded(m_jukebox_queue.size() -1);
         l_song_name = m_jukebox_queue[l_random_index];
-        emit playJukeboxSong(AOPacket("MC",{l_song_name,QString::number(-1)}), m_index);
-        m_jukebox_timer->start(ConfigManager::songInformation(m_jukebox_queue[l_random_index]) * 1000);
+
+        QPair<QString,float> l_song = ConfigManager::songInformation(l_song_name);
+        emit playJukeboxSong(AOPacket("MC",{l_song.first,"-1"}), m_index);
+        m_jukebox_timer->start(l_song.second * 1000);
+
         m_jukebox_queue.remove(l_random_index);
         m_jukebox_queue.squeeze();
     }

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -25,7 +25,7 @@ QSettings* ConfigManager::m_areas = new QSettings("config/areas.ini", QSettings:
 QSettings* ConfigManager::m_logtext = new QSettings("config/text/logtext.ini", QSettings::IniFormat);
 ConfigManager::CommandSettings* ConfigManager::m_commands = new CommandSettings();
 QElapsedTimer* ConfigManager::m_uptimeTimer = new QElapsedTimer;
-QHash<QString,float>* ConfigManager::m_musicList = new QHash<QString,float>;
+QHash<QString,QPair<QString,float>>* ConfigManager::m_musicList = new QHash<QString,QPair<QString,float>>;
 QHash<QString,ConfigManager::help>* ConfigManager::m_commands_help = new QHash<QString,ConfigManager::help>;
 
 bool ConfigManager::verifyServerConfig()
@@ -152,7 +152,7 @@ QStringList ConfigManager::musiclist()
         //Technically not a requirement, but neat for organisation.
         QString l_category_name = l_child_obj["category"].toString();
         if (!l_category_name.isEmpty()) {
-            m_musicList->insert(l_category_name,0);
+            m_musicList->insert(l_category_name,{l_category_name,0});
             l_musiclist.append(l_category_name);
         }
         else {
@@ -163,8 +163,12 @@ QStringList ConfigManager::musiclist()
         for (int i = 0; i <= l_child_array.size() -1; i++){ // Inner for loop because a category can contain multiple songs.
             QJsonObject l_song_obj = l_child_array.at(i).toObject();
             QString l_song_name = l_song_obj["name"].toString();
-            int l_song_duration = l_song_obj["length"].toVariant().toFloat();
-         m_musicList->insert(l_song_name,l_song_duration);
+            QString l_real_name = l_song_obj["realname"].toString();
+            if (l_real_name.isEmpty()) {
+                l_real_name = l_song_name;
+            }
+            float l_song_duration = l_song_obj["length"].toVariant().toFloat();
+         m_musicList->insert(l_song_name,{l_real_name,l_song_duration});
          l_musiclist.append(l_song_name);
         }
     }
@@ -207,7 +211,7 @@ void ConfigManager::loadCommandHelp()
     }
 }
 
-int ConfigManager::songInformation(const QString &f_songName)
+QPair<QString,float> ConfigManager::songInformation(const QString &f_songName)
 {
     return m_musicList->value(f_songName);
 }

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -299,42 +299,42 @@ void AOClient::pktChangeMusic(AreaData* area, int argc, QStringList argv, AOPack
     // argument is a valid song
     QString l_argument = argv[0];
 
-    for (const QString &l_song : qAsConst(server->m_music_list)) {
-        if (l_song == l_argument || l_song == "~stop.mp3") { // ~stop.mp3 is a dummy track used by 2.9+
-            // We have a song here
-            if (m_is_dj_blocked) {
-                sendServerMessage("You are blocked from changing the music.");
-                return;
-            }
-            if (!area->isMusicAllowed() && !checkAuth(ACLFlags.value("CM"))) {
-                sendServerMessage("Music is disabled in this area.");
-                return;
-            }
-            QString l_effects;
-            if (argc >= 4)
-                l_effects = argv[3];
-            else
-                l_effects = "0";
-            QString l_final_song;
-            if (!l_argument.contains("."))
-                l_final_song = "~stop.mp3";
-            else
-                l_final_song = l_argument;
-
-            //Jukebox intercepts the direct playing of messages.
-            if (area->isjukeboxEnabled()) {
-                QString l_jukebox_reply = area->addJukeboxSong(l_final_song);
-                sendServerMessage(l_jukebox_reply);
-                return;
-            }
-
-
-            AOPacket l_music_change("MC", {l_final_song, argv[1], m_showname, "1", "0", l_effects});
-            area->setCurrentMusic(l_final_song);
-            area->setMusicPlayedBy(m_showname);
-            server->broadcast(l_music_change, m_current_area);
+    if (server->m_music_list.contains(l_argument) || l_argument == "~stop.mp3") { // ~stop.mp3 is a dummy track used by 2.9+
+        // We have a song here
+        if (m_is_dj_blocked) {
+            sendServerMessage("You are blocked from changing the music.");
             return;
         }
+        if (!area->isMusicAllowed() && !checkAuth(ACLFlags.value("CM"))) {
+            sendServerMessage("Music is disabled in this area.");
+            return;
+        }
+        QString l_effects;
+        if (argc >= 4)
+            l_effects = argv[3];
+        else
+            l_effects = "0";
+        QString l_final_song;
+        if (!l_argument.contains("."))
+            l_final_song = "~stop.mp3";
+        else
+            l_final_song = l_argument;
+
+        //Jukebox intercepts the direct playing of messages.
+        if (area->isjukeboxEnabled()) {
+            QString l_jukebox_reply = area->addJukeboxSong(l_final_song);
+            sendServerMessage(l_jukebox_reply);
+            return;
+        }
+
+        QPair<QString,float> l_song = ConfigManager::songInformation(l_final_song);
+        QString l_real_name = l_song.first;
+        qDebug() << l_real_name;
+        AOPacket l_music_change("MC", {l_real_name, argv[1], m_showname, "1", "0", l_effects});
+        area->setCurrentMusic(l_final_song);
+        area->setMusicPlayedBy(m_showname);
+        server->broadcast(l_music_change, m_current_area);
+        return;
     }
 
     for (int i = 0; i < server->m_area_names.length(); i++) {


### PR DESCRIPTION
Allows you to alias songs by providing the main name as a "Friendly name", while the actual song name can be an URL or a different name.

Solves the ancient issue of "but MOM, it's called [Insert Japanese Weaboo name here" and allows servers without dedicated WebAO repository to have their music be streams.