### PR TITLE
Change broadcast to area to use userIDs instead of iterating over all joined clients.

### DIFF
--- a/core/include/area_data.h
+++ b/core/include/area_data.h
@@ -215,8 +215,11 @@ class AreaData : public QObject {
      *
      * @param f_charId The character ID of the client who left. The default value is `-1`. If it is left at that,
      * the area will not try to remove any character from the list of characters taken.
+     *
+     * @param f_userId The user ID of the client who left. The default value is '-1', This ID is technically
+     * impossible.
      */
-    void clientLeftArea(int f_charId = -1);
+    void clientLeftArea(int f_charId = -1, int f_userId = -1);
 
     /**
      * @brief A client in the area joined recently.
@@ -225,8 +228,11 @@ class AreaData : public QObject {
      *
      * @param f_charId The character ID of the client who joined. The default value is `-1`. If it is left at that,
      * the area will not add any character to the list of characters taken.
+     *
+     * @param f_userId The user ID of the client who left. The default value is '-1', This ID is technically
+     * impossible.
      */
-    void clientJoinedArea(int f_charId = -1);
+    void clientJoinedArea(int f_charId = -1, int f_userId = -1);
 
     /**
      * @brief Returns a copy of the list of owners of this area.
@@ -844,6 +850,11 @@ class AreaData : public QObject {
      */
     QString addJukeboxSong(QString f_song);
 
+    /**
+     * @brief Returns a constant that includes all currently joined userids.
+     */
+    QVector<int> joinedIDs() const;
+
 public slots:
 
     /**
@@ -1059,6 +1070,11 @@ private:
      * @brief Whether or not the area message is sent upon area join.
      */
     bool m_send_area_message;
+
+    /**
+     * @brief Collection of joined IDs to this area.
+     */
+    QVector<int> m_joined_ids;
 
     // Jukebox specific members
     /**

--- a/core/src/aoclient.cpp
+++ b/core/src/aoclient.cpp
@@ -55,7 +55,7 @@ void AOClient::clientDisconnected()
     if (m_joined) {
         server->m_player_count--;
         emit server->updatePlayerCount(server->m_player_count);
-        server->m_areas[m_current_area]->clientLeftArea(server->getCharID(m_current_char));
+        server->m_areas[m_current_area]->clientLeftArea(server->getCharID(m_current_char), m_id);
         arup(ARUPType::PLAYER_COUNT, true);
     }
 
@@ -124,14 +124,14 @@ void AOClient::changeArea(int new_area)
         server->m_areas[m_current_area]->changeCharacter(server->getCharID(m_current_char), -1);
         server->updateCharsTaken(server->m_areas[m_current_area]);
     }
-    server->m_areas[m_current_area]->clientLeftArea(m_char_id);
+    server->m_areas[m_current_area]->clientLeftArea(m_char_id, m_id);
     bool l_character_taken = false;
     if (server->m_areas[new_area]->charactersTaken().contains(server->getCharID(m_current_char))) {
         m_current_char = "";
         m_char_id = -1;
         l_character_taken = true;
     }
-    server->m_areas[new_area]->clientJoinedArea(m_char_id);
+    server->m_areas[new_area]->clientJoinedArea(m_char_id, m_id);
     m_current_area = new_area;
     arup(ARUPType::PLAYER_COUNT, true);
     sendEvidenceList(server->m_areas[new_area]);

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -75,22 +75,24 @@ const QMap<QString, AreaData::Status> AreaData::map_statuses = {
     {"gaming",                  AreaData::Status::GAMING              },
 };
 
-void AreaData::clientLeftArea(int f_charId)
+void AreaData::clientLeftArea(int f_charId, int f_userId)
 {
     --m_playerCount;
 
     if (f_charId != -1) {
         m_charactersTaken.removeAll(f_charId);
     }
+    m_joined_ids.removeAll(f_userId);
 }
 
-void AreaData::clientJoinedArea(int f_charId)
+void AreaData::clientJoinedArea(int f_charId, int f_userId)
 {
     ++m_playerCount;
 
     if (f_charId != -1) {
         m_charactersTaken.append(f_charId);
     }
+    m_joined_ids.append(f_userId);
 }
 
 QList<int> AreaData::owners() const
@@ -577,6 +579,11 @@ QString AreaData::addJukeboxSong(QString f_song)
             }
     }
     return "Unable to add song. Song already in Jukebox.";
+}
+
+QVector<int> AreaData::joinedIDs() const
+{
+    return m_joined_ids;
 }
 
 void AreaData::switchJukeboxSong()

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -134,7 +134,7 @@ void AOClient::pktLoadingDone(AreaData* area, int argc, QStringList argv, AOPack
 
     server->m_player_count++;
     emit server->updatePlayerCount(server->m_player_count);
-    area->clientJoinedArea();
+    area->clientJoinedArea(-1, m_id);
     m_joined = true;
     server->updateCharsTaken(area);
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -253,9 +253,9 @@ void Server::reloadSettings()
 
 void Server::broadcast(AOPacket packet, int area_index)
 {
-    for (AOClient* client : qAsConst(m_clients)) {
-        if (client->m_current_area == area_index)
-            client->sendPacket(packet);
+    QVector<int> l_client_ids = m_areas.value(area_index)->joinedIDs();
+    for (const int l_client_id : qAsConst(l_client_ids)) {
+        getClientByID(l_client_id)->sendPacket(packet);
     }
 }
 

--- a/tests/unittest_area/tst_unittest_area.cpp
+++ b/tests/unittest_area/tst_unittest_area.cpp
@@ -77,17 +77,17 @@ void Area::cleanup()
 void Area::clientJoinLeave()
 {
     {
-        // There must be exactly one client in the area, and it must have a charid of 5.
-        m_area->clientJoinedArea(5);
+        // There must be exactly one client in the area, and it must have a charid of 5 and userid 0.
+        m_area->clientJoinedArea(5,0);
 
-        QCOMPARE(m_area->charactersTaken().size(), 1);
+        QCOMPARE(m_area->joinedIDs().size(), 1);
         QCOMPARE(m_area->charactersTaken().at(0), 5);
     }
     {
         // No clients must be left in the area.
-        m_area->clientLeftArea(5);
+        m_area->clientLeftArea(5,0);
 
-        QCOMPARE(m_area->charactersTaken().size(), 0);
+        QCOMPARE(m_area->joinedIDs().size(), 0);
     }
 }
 
@@ -151,8 +151,8 @@ void Area::changeHP()
 void Area::changeCharacter()
 {
     {
-        // A client with a charid of 6 joins. There's only them in there.
-        m_area->clientJoinedArea(6);
+        // A client with a charid of 6 and userid 0 joins. There's only them in there.
+        m_area->clientJoinedArea(6,0);
 
         QCOMPARE(m_area->charactersTaken().size(), 1);
         QCOMPARE(m_area->charactersTaken().at(0), 6);


### PR DESCRIPTION
Adds the server-assigned clientid to the area, allowing the server to exclusively broadcast to this area without checking each clients area.
Tests have been adjusted to account that area leaving and joining can now be identified by userid.