### PR TITLE
Add server description to the PN packet

### DIFF
--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -75,6 +75,7 @@ void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacke
     }
 
     sendPacket("PN", {QString::number(server->m_player_count), QString::number(ConfigManager::maxPlayers())});
+    sendPacket("SDESC", {ConfigManager::serverDescription()});
     sendPacket("FL", l_feature_list);
 
     if (ConfigManager::assetUrl().isValid()) {

--- a/core/src/packets.cpp
+++ b/core/src/packets.cpp
@@ -74,8 +74,7 @@ void AOClient::pktSoftwareId(AreaData* area, int argc, QStringList argv, AOPacke
         m_version.minor = l_match.captured(3).toInt();
     }
 
-    sendPacket("PN", {QString::number(server->m_player_count), QString::number(ConfigManager::maxPlayers())});
-    sendPacket("SDESC", {ConfigManager::serverDescription()});
+    sendPacket("PN", {QString::number(server->m_player_count), QString::number(ConfigManager::maxPlayers()), ConfigManager::serverDescription()});
     sendPacket("FL", l_feature_list);
 
     if (ConfigManager::assetUrl().isValid()) {


### PR DESCRIPTION
This packet allows servers to overwrite the server description, allowing them to display them even in the favourites menu.