### PR TITLE
Fix help displaying nothing if it can't find the command + loadCommandHelp variable name fixes

### DIFF
--- a/core/src/commands/moderation.cpp
+++ b/core/src/commands/moderation.cpp
@@ -170,11 +170,15 @@ void AOClient::cmdHelp(int argc, QStringList argv)
 {
     if(argc > 1) {
         sendServerMessage("Too many arguments. Please only use the command name.");
+        return;
     }
 
     QString l_command_name = argv[0];
     ConfigManager::help l_command_info = ConfigManager::commandHelp(l_command_name);
-    sendServerMessage("==Help==\n" +l_command_info.usage + "\n" + l_command_info.text);
+    if (l_command_info.usage.isEmpty() || l_command_info.text.isEmpty()) // my picoseconds :(
+        sendServerMessage("Unable to find the command " + l_command_name + ".");
+    else
+        sendServerMessage("==Help==\n" +l_command_info.usage + "\n" + l_command_info.text);
 }
 
 void AOClient::cmdMOTD(int argc, QStringList argv)

--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -185,17 +185,17 @@ QStringList ConfigManager::ordered_songs()
 
 void ConfigManager::loadCommandHelp()
 {
-    QFile l_music_json("config/text/commandhelp.json");
-    l_music_json.open(QIODevice::ReadOnly | QIODevice::Text);
+    QFile l_help_json("config/text/commandhelp.json");
+    l_help_json.open(QIODevice::ReadOnly | QIODevice::Text);
 
     QJsonParseError l_error;
-    QJsonDocument l_music_list_json = QJsonDocument::fromJson(l_music_json.readAll(), &l_error);
+    QJsonDocument l_help_list_json = QJsonDocument::fromJson(l_help_json.readAll(), &l_error);
     if (!(l_error.error == QJsonParseError::NoError)) { //Non-Terminating error.
         qWarning() << "Unable to load help information. The following error occurred: " + l_error.errorString();
     }
 
     // Akashi expects the helpfile to contain multiple entires, so it always checks for an array first.
-    QJsonArray l_Json_root_array = l_music_list_json.array();
+    QJsonArray l_Json_root_array = l_help_list_json.array();
     QJsonObject l_child_obj;
 
     for (int i = 0; i <= l_Json_root_array.size() -1; i++){


### PR DESCRIPTION
> Correct loadCommandHelp variable names, return if too many arguments on help, and add behaviour if no help exists

Fixes the following odd behaviour snippets:

/help asdf
![image](https://user-images.githubusercontent.com/30537683/159205267-6a5ed2c0-26c0-4b45-a18d-5b14ee752854.png)

/help baninfo 19 dollar fortnite card
![image](https://user-images.githubusercontent.com/30537683/159205420-97d0b1f3-164d-42b4-b502-e067cd1ad6e2.png)

