### PR TITLE
Don't Display IPIDs to Users via Global Chat

### DIFF
--- a/core/src/commands/messaging.cpp
+++ b/core/src/commands/messaging.cpp
@@ -72,9 +72,9 @@ void AOClient::cmdG(int argc, QStringList argv)
     QString l_sender_area = server->m_area_names.value(m_current_area);
     QString l_sender_message = argv.join(" ");
     //Slightly better readability
-    AOPacket l_packet = AOPacket("CT", {"[G][" + m_ipid + "][" + l_sender_area + "]" + l_sender_name, l_sender_message});
-    AOPacket l_other_packet = AOPacket("CT", {"[G][" + l_sender_area + "]" + l_sender_name, l_sender_message});
-    server->broadcast(l_packet, l_other_packet, Server::TARGET_TYPE::AUTHENTICATED);
+    AOPacket l_mod_packet = AOPacket("CT", {"[G][" + m_ipid + "][" + l_sender_area + "]" + l_sender_name, l_sender_message});
+    AOPacket l_user_packet = AOPacket("CT", {"[G][" + l_sender_area + "]" + l_sender_name, l_sender_message});
+    server->broadcast(l_user_packet, l_mod_packet, Server::TARGET_TYPE::AUTHENTICATED);
     return;
 }
 


### PR DESCRIPTION
Slightly better variable names too while we're at it

In a longer explanation, the behaviour was flipped, and users saw IPIDs while mods saw nothing, rather than the other way around.