### PR TITLE
Ensure /changepass always has arg 0 as the password

### DIFF
--- a/core/src/commands/authentication.cpp
+++ b/core/src/commands/authentication.cpp
@@ -270,18 +270,16 @@ void AOClient::cmdLogout(int argc, QStringList argv)
 void AOClient::cmdChangePassword(int argc, QStringList argv)
 {
     QString l_username;
-    QString l_password;
+    QString l_password = argv[0];
     if (argc == 1) {
         if (m_moderator_name.isEmpty()) {
             sendServerMessage("You are not logged in.");
             return;
         }
         l_username = m_moderator_name;
-        l_password = argv[0];
     }
     else if (argc == 2 && checkAuth(ACLFlags.value("SUPER"))) {
-        l_username = argv[0];
-        l_password = argv[1];
+        l_username = argv[1];
     }
     else {
         sendServerMessage("Invalid command syntax.");


### PR DESCRIPTION
Otherwise, the syntax is `/changepass <Password>` or `/changepass <Moderator> <Password>`, rather than `/changepass <Password> 'Moderator'`, like how it's specified to be

(I meant arg 0 in my own commit, but basically, the first argument should be the password)

![image](https://user-images.githubusercontent.com/30537683/167075438-772aa923-da47-48b8-9f1c-4dbf02d84589.png)
