### PR TITLE
Fix Discord Webhook not working unless webhook_color has a value in the config

### DIFF
--- a/core/src/config_manager.cpp
+++ b/core/src/config_manager.cpp
@@ -473,7 +473,13 @@ QString ConfigManager::discordUptimeWebhookUrl()
 
 QString ConfigManager::discordWebhookColor()
 {
-    return m_discord->value("Discord/webhook_color","13312842").toString();
+    QString l_color = m_discord->value("Discord/webhook_color", "13312842").toString();
+    if (l_color.isEmpty()) {
+        return "13312842";
+    }
+    else {
+        return l_color;
+    }
 }
 
 bool ConfigManager::passwordRequirements()


### PR DESCRIPTION
Fixes a negative IQ bug introduced by yours truly, causing Akashi to load an empty color code, causing Discord to reject the Webhook due to an empty value.