### PR TITLE
Add OpenSSL to Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,9 +72,8 @@ jobs:
         run: |
           curl https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1o.zip --output openssl-1.1.1o.zip
           tar -xf openssl-1.1.1o.zip
-          copy .\openssl-1.1.1o\openssl-1.1\x64\bin\libcrypto-1_1-x64.dll .\bin\libcrypto-1_1-x64.dll 
-          copy .\openssl-1.1.1o\openssl-1.1\x64\bin\libssl-1_1-x64.dll .\bin\libssl-1_1-x64.dll
-
+          copy .\openssl-1.1\x64\bin\libcrypto-1_1-x64.dll .\bin\libcrypto-1_1-x64.dll 
+          copy .\openssl-1.1\x64\bin\libssl-1_1-x64.dll .\bin\libssl-1_1-x64.dll
           
       - name: Upload zip
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,14 @@ jobs:
             LD_LIBRARY_PATH=./bin:$LD_LIBRARY_PATH ./$test
           done;
         shell: bash
+
+      - name: Deploy OpenSSL
+        run: |
+          curl https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1o.zip --output openssl-1.1.1o.zip
+          tar -xf openssl-1.1.1o.zip
+          copy .\openssl-1.1.1o\openssl-1.1\x64\bin\libcrypto-1_1-x64.dll .\bin\libcrypto-1_1-x64.dll 
+          copy .\openssl-1.1.1o\openssl-1.1\x64\bin\libssl-1_1-x64.dll .\bin\libssl-1_1-x64.dll
+
           
       - name: Upload zip
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This prevents TLS issues due to the lack of OpenSSL in the user's path.