### PR TITLE
Expand kick_other to consider the hwid

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -1367,6 +1367,9 @@ class AOClient : public QObject
      *
      * @details This command gracefully removes all multiclients from the server, disconnecting them and freeing their used character.
      *
+     * @arg argv This command allows the user to specify if it should look for IPID or HWID matches. This is useful when a client mayb
+     * have been connected over IPv6 and the second connection is made over IPv4
+     *
      * @iscommand
      */
     void cmdKickOther(int argc, QStringList argv);

--- a/core/include/server.h
+++ b/core/include/server.h
@@ -118,6 +118,15 @@ class Server : public QObject
     QList<AOClient *> getClientsByIpid(QString ipid);
 
     /**
+     * @brief Gets a list of pointers to all clients with the given HWID.
+     *
+     * @param HWID The HWID to look for.
+     *
+     * @return A list of clients whose HWID match. List may be empty.
+     */
+    QList<AOClient *> getClientsByHwid(QString f_hwid);
+
+    /**
      * @brief Gets a pointer to a client by user ID.
      *
      * @param id The user ID to look for.

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -456,6 +456,16 @@ QList<AOClient *> Server::getClientsByIpid(QString ipid)
     return return_clients;
 }
 
+QList<AOClient *> Server::getClientsByHwid(QString f_hwid)
+{
+    QList<AOClient *> return_clients;
+    for (AOClient *l_client : qAsConst(m_clients)) {
+        if (l_client->getHwid() == f_hwid)
+            return_clients.append(l_client);
+    }
+    return return_clients;
+}
+
 AOClient *Server::getClientByID(int id)
 {
     return m_clients_ids.value(id);


### PR DESCRIPTION
closes #275 
Adds an hwid lookup to the kick_other to account for potential IP issues due to IPv6/IPv4 protocol shenanigans.
This is not foolproof because a client can only kick_other other clients and same IPID, same with WebAO. 
About as good as we can make it.