### PR TITLE
Add regression test to ACL ini handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ Thumbs.db
 build/
 bin/akashi
 bin/config/
-bin_tests/
+bin_tests/unittest_*
 bin/logs/
 bin/core.lib
 bin/libcore.a

--- a/bin_tests/config/acl_roles.ini
+++ b/bin_tests/config/acl_roles.ini
@@ -1,0 +1,17 @@
+;Thanks to AwesomeAim for providing this malfunctioning ini
+[moderator]
+kick = true
+mute = true
+chat_moderator = true
+gamemaster = false
+lock_background = true
+bypass_locks = true
+ignore_background_list = true
+ban = true
+
+[supervisor]
+ban = true
+kick = true
+mute = true
+chat_moderator = true
+modify_users = true

--- a/core/include/acl_roles_handler.h
+++ b/core/include/acl_roles_handler.h
@@ -7,6 +7,7 @@
 
 class ACLRole
 {
+    Q_GADGET
   public:
     /**
      * @brief This enum is used to specify permissions of a role.
@@ -35,6 +36,7 @@ class ACLRole
         SUPER = 0xffffffff,
     };
     Q_DECLARE_FLAGS(Permissions, Permission);
+    Q_ENUM(Permission);
 
     /**
      * @brief Shared read-only captions for each permissions.

--- a/core/src/acl_roles_handler.cpp
+++ b/core/src/acl_roles_handler.cpp
@@ -203,10 +203,12 @@ bool ACLRolesHandler::loadFile(QString f_file_name)
         ACLRole l_role;
         const QList<ACLRole::Permission> l_permissions = ACLRole::PERMISSION_CAPTIONS.keys();
         for (const ACLRole::Permission &i_permission : l_permissions) {
-            l_role.setPermission(i_permission, l_settings.value(ACLRole::PERMISSION_CAPTIONS.value(i_permission), false).toBool());
+            const QVariant l_value = l_settings.value(ACLRole::PERMISSION_CAPTIONS.value(i_permission));
+            if (l_value.isValid()) {
+                l_role.setPermission(i_permission, l_value.toBool());
+            }
         }
         m_roles.insert(l_upper_group, std::move(l_role));
-
         l_settings.endGroup();
     }
 

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -44,7 +44,7 @@ Server::Server(int p_port, int p_ws_port, QObject *parent) :
 
     db_manager = new DBManager;
 
-    acl_roles_handler = new ACLRolesHandler;
+    acl_roles_handler = new ACLRolesHandler(this);
     acl_roles_handler->loadFile("config/acl_roles.ini");
 
     command_extension_collection = new CommandExtensionCollection;

--- a/tests/unittest_acl_roles_handler/tst_unittest_acl_roles_handler.cpp
+++ b/tests/unittest_acl_roles_handler/tst_unittest_acl_roles_handler.cpp
@@ -179,6 +179,10 @@ void tst_ACLRolesHandler::modifyRoles()
 void tst_ACLRolesHandler::loadRolesFromIni()
 {
     {
+        QFile config_file("config/acl_roles.ini");
+        QCOMPARE(config_file.exists(), true);
+    }
+    {
         m_handler->loadFile("config/acl_roles.ini");
     }
     {

--- a/tests/unittest_acl_roles_handler/tst_unittest_acl_roles_handler.cpp
+++ b/tests/unittest_acl_roles_handler/tst_unittest_acl_roles_handler.cpp
@@ -44,6 +44,11 @@ class tst_ACLRolesHandler : public QObject
     void modifyRoles();
 
     /**
+     * @brief Tests file loading of roles and correct permission assignment.
+     */
+    void loadRolesFromIni();
+
+    /**
      * @brief Tests clearance of roles.
      */
     void clearAllRoles();
@@ -60,7 +65,7 @@ void tst_ACLRolesHandler::checkReadOnlyRoles()
         const QString l_role_name = ACLRolesHandler::NONE_ID;
 
         // Checks if the role exists
-        QCOMPARE(m_handler->roleExists(ACLRolesHandler::NONE_ID), true);
+        QCOMPARE(m_handler->roleExists(l_role_name), true);
 
         ACLRole l_role = m_handler->getRoleById(ACLRolesHandler::NONE_ID);
         // Checks every permissions
@@ -168,6 +173,39 @@ void tst_ACLRolesHandler::modifyRoles()
 
         // Checks if the role exists. This should fail.
         QCOMPARE(m_handler->roleExists(l_role_id), false);
+    }
+}
+
+void tst_ACLRolesHandler::loadRolesFromIni()
+{
+    {
+        m_handler->loadFile("config/acl_roles.ini");
+    }
+    {
+        QString l_role_id = "moderator";
+        QCOMPARE(m_handler->roleExists(l_role_id), true);
+        ACLRole l_role = m_handler->getRoleById(l_role_id);
+
+        QCOMPARE(l_role.checkPermission(ACLRole::NONE), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::KICK), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::BAN), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::BGLOCK), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::MODIFY_USERS), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::CM), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::GLOBAL_TIMER), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::EVI_MOD), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::MOTD), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::ANNOUNCE), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::MODCHAT), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::MUTE), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::UNCM), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::SAVETEST), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::FORCE_CHARSELECT), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::BYPASS_LOCKS), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::IGNORE_BGLIST), true);
+        QCOMPARE(l_role.checkPermission(ACLRole::SEND_NOTICE), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::JUKEBOX), false);
+        QCOMPARE(l_role.checkPermission(ACLRole::SUPER), false);
     }
 }
 


### PR DESCRIPTION
Something went fucky on the diff as it somehow appended the changes from master, whatev.
Apprenty using QSettings in correlation to QTest is a bad idea, but worked fine on my machine™