### PR TITLE
Remove excessive spacing with /notecardreveal

### DIFF
--- a/core/src/commands/roleplay.cpp
+++ b/core/src/commands/roleplay.cpp
@@ -170,7 +170,7 @@ void AOClient::cmdNoteCardReveal(int argc, QStringList argv)
     }
 
     QString l_message("Note cards have been revealed.\n");
-    l_message.append(l_notecards.join("\n") + "\n");
+    l_message.append(l_notecards.join(""));
 
     sendServerMessageArea(l_message);
 }


### PR DESCRIPTION
Barely any change here, but it goes from
![image](https://user-images.githubusercontent.com/30537683/176434435-c2fe310b-8544-422c-9d64-58c598b75a27.png)
to
![image](https://user-images.githubusercontent.com/30537683/176434488-4a766e34-9e9c-4e05-a065-373945559c6d.png)