### PR TITLE
Added dice notation to help command

### DIFF
--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -2038,7 +2038,7 @@ class AOClient : public QObject
      * @param dice The number of dice to be rolled
      *
      * @param p_roll Bool to determine of a roll is private or not.
-     * 
+     *
      * @param roll_modifier Option parameter to add or subtract from each
      * rolled value
      */

--- a/core/include/aoclient.h
+++ b/core/include/aoclient.h
@@ -2033,13 +2033,16 @@ class AOClient : public QObject
     /**
      * @brief A convenience function for rolling dice.
      *
-     * @param argc The amount of arguments.
+     * @param sides The number of sides the dice to be rolled have
      *
-     * @param argv Stringlist of the arguments given by the client.
+     * @param dice The number of dice to be rolled
      *
      * @param p_roll Bool to determine of a roll is private or not.
+     * 
+     * @param roll_modifier Option parameter to add or subtract from each
+     * rolled value
      */
-    void diceThrower(int argc, QStringList argv, bool p_roll);
+    void diceThrower(int sides, int dice, bool p_roll, int roll_modifier = 0);
 
     /**
      * @brief Interprets an expression of time into amount of seconds.

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -84,25 +84,30 @@ int AOClient::genRand(int min, int max)
 #endif
 }
 
-void AOClient::diceThrower(int argc, QStringList argv, bool p_roll)
+void AOClient::diceThrower(int sides, int dice, bool p_roll, int roll_modifier)
 {
-    int l_sides = 6;
-    int l_dice = 1;
+    if (sides < 0 || dice < 0 || sides > 99999 || dice > 99999) {
+        sendServerMessage("Dice or side number out of bounds.");
+        return;
+    }
     QStringList results;
-    if (argc >= 1)
-        l_sides = qBound(1, argv[0].toInt(), ConfigManager::diceMaxValue());
-    if (argc == 2)
-        l_dice = qBound(1, argv[1].toInt(), ConfigManager::diceMaxDice());
-    for (int i = 1; i <= l_dice; i++) {
-        results.append(QString::number(AOClient::genRand(1, l_sides)));
+    for (int i = 1; i <= dice; i++) {
+        results.append(QString::number(AOClient::genRand(1, sides) + roll_modifier));
     }
     QString total_results = results.join(" ");
     if (p_roll) {
-        sendServerMessage("You rolled a " + QString::number(l_dice) + "d" + QString::number(l_sides) + ". Results: " + total_results);
+        if (roll_modifier)
+            sendServerMessage("You rolled a " + QString::number(dice) + "d" + QString::number(sides) + "+" + QString::number(roll_modifier) + ". Results: " + total_results);
+        else
+            sendServerMessage("You rolled a " + QString::number(dice) + "d" + QString::number(sides) + ". Results: " + total_results);
         return;
     }
-    sendServerMessageArea(m_ooc_name + " rolled a " + QString::number(l_dice) + "d" + QString::number(l_sides) + ". Results: " + total_results);
+    if (roll_modifier)
+        sendServerMessageArea(m_ooc_name + " rolled a " + QString::number(dice) + "d" + QString::number(sides) + "+" + QString::number(roll_modifier) + ". Results: " + total_results);
+    else
+        sendServerMessageArea(m_ooc_name + " rolled a " + QString::number(dice) + "d" + QString::number(sides) + ". Results: " + total_results);
 }
+
 
 QString AOClient::getAreaTimer(int area_idx, int timer_idx)
 {

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -86,7 +86,7 @@ int AOClient::genRand(int min, int max)
 
 void AOClient::diceThrower(int sides, int dice, bool p_roll, int roll_modifier)
 {
-    if (sides < 0 || dice < 0 || sides > 99999 || dice > 99999) {
+    if (sides < 0 || dice < 0 || sides > ConfigManager::diceMaxValue || dice > ConfigManager::diceMaxDice) {
         sendServerMessage("Dice or side number out of bounds.");
         return;
     }

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -108,7 +108,6 @@ void AOClient::diceThrower(int sides, int dice, bool p_roll, int roll_modifier)
         sendServerMessageArea(m_ooc_name + " rolled a " + QString::number(dice) + "d" + QString::number(sides) + ". Results: " + total_results);
 }
 
-
 QString AOClient::getAreaTimer(int area_idx, int timer_idx)
 {
     AreaData *l_area = server->getAreaById(area_idx);

--- a/core/src/commands/command_helper.cpp
+++ b/core/src/commands/command_helper.cpp
@@ -86,7 +86,7 @@ int AOClient::genRand(int min, int max)
 
 void AOClient::diceThrower(int sides, int dice, bool p_roll, int roll_modifier)
 {
-    if (sides < 0 || dice < 0 || sides > ConfigManager::diceMaxValue || dice > ConfigManager::diceMaxDice) {
+    if (sides < 0 || dice < 0 || sides > ConfigManager::diceMaxValue() || dice > ConfigManager::diceMaxDice()) {
         sendServerMessage("Dice or side number out of bounds.");
         return;
     }

--- a/core/src/commands/roleplay.cpp
+++ b/core/src/commands/roleplay.cpp
@@ -38,12 +38,114 @@ void AOClient::cmdFlip(int argc, QStringList argv)
 
 void AOClient::cmdRoll(int argc, QStringList argv)
 {
-    diceThrower(argc, argv, false);
+    int l_sides = 6;
+    int l_dice = 1;
+    QStringList results;
+
+    if (argc >= 1) {
+        if (argv[0].contains('d')) {
+            QStringList l_arguments = argv[0].split('d');
+
+            bool l_dice_ok;
+            bool l_sides_ok;
+            l_dice = l_arguments[0].toInt(&l_dice_ok);
+            l_sides = l_arguments[1].toInt(&l_sides_ok);
+
+            if (argv[0].contains('+')) {
+                bool l_mod_ok;
+                QStringList l_modifier = l_arguments[1].split('+');
+                int modifier = l_modifier[1].toInt(&l_mod_ok);
+                l_sides = l_modifier[0].toInt(&l_sides_ok);
+
+                if (l_mod_ok && l_dice_ok && l_sides_ok)
+                    diceThrower(l_sides, l_dice, false, modifier);
+                else
+                    sendServerMessage("Invalid dice notation.");
+                return;
+            }
+            else if (argv[0].contains('-')) {
+                bool l_mod_ok;
+                QStringList l_modifier = l_arguments[1].split('-');
+                int modifier = l_modifier[1].toInt(&l_mod_ok);
+                l_sides = l_modifier[0].toInt(&l_sides_ok);
+
+                if (l_mod_ok && l_dice_ok && l_sides_ok)
+                    diceThrower(l_sides, l_dice, false, -modifier);
+                else
+                    sendServerMessage("Invalid dice notation.");
+                return;
+            }
+            else if (l_dice_ok && l_sides_ok) {
+                diceThrower(l_sides, l_dice, false);
+                return;
+            }
+            else {
+                sendServerMessage("Invalid dice notation.");
+                return;
+            }
+        }
+        else
+            l_sides = qBound(1, argv[0].toInt(), ConfigManager::diceMaxValue());
+    }
+    if (argc == 2)
+        l_dice = qBound(1, argv[1].toInt(), ConfigManager::diceMaxDice());
+    diceThrower(l_sides, l_dice, false);
 }
 
 void AOClient::cmdRollP(int argc, QStringList argv)
 {
-    diceThrower(argc, argv, true);
+    int l_sides = 6;
+    int l_dice = 1;
+    QStringList results;
+
+    if (argc >= 1) {
+        if (argv[0].contains('d')) {
+            QStringList l_arguments = argv[0].split('d');
+
+            bool l_dice_ok;
+            bool l_sides_ok;
+            l_dice = l_arguments[0].toInt(&l_dice_ok);
+            l_sides = l_arguments[1].toInt(&l_sides_ok);
+
+            if (argv[0].contains('+')) {
+                bool l_mod_ok;
+                QStringList l_modifier = l_arguments[1].split('+');
+                int modifier = l_modifier[1].toInt(&l_mod_ok);
+                l_sides = l_modifier[0].toInt(&l_sides_ok);
+
+                if (l_mod_ok && l_dice_ok && l_sides_ok)
+                    diceThrower(l_sides, l_dice, true, modifier);
+                else
+                    sendServerMessage("Invalid dice notation.");
+                return;
+            }
+            else if (argv[0].contains('-')) {
+                bool l_mod_ok;
+                QStringList l_modifier = l_arguments[1].split('-');
+                int modifier = l_modifier[1].toInt(&l_mod_ok);
+                l_sides = l_modifier[0].toInt(&l_sides_ok);
+
+                if (l_mod_ok && l_dice_ok && l_sides_ok)
+                    diceThrower(l_sides, l_dice, true, -modifier);
+                else
+                    sendServerMessage("Invalid dice notation.");
+                return;
+            }
+            else if (l_dice_ok && l_sides_ok) {
+                diceThrower(l_sides, l_dice, true);
+                return;
+            }
+            else {
+                sendServerMessage("Invalid dice notation.");
+                return;
+            }
+        }
+        else
+            l_sides = qBound(1, argv[0].toInt(), ConfigManager::diceMaxValue());
+    }
+    if (argc == 2)
+        l_dice = qBound(1, argv[1].toInt(), ConfigManager::diceMaxDice());
+    diceThrower(l_sides, l_dice, true);
 }
 
 void AOClient::cmdTimer(int argc, QStringList argv)


### PR DESCRIPTION
Resolves #285 

I thought it was best to separate all the argument parsing into cmdRoll and all the dice rolling/server message stuff into diceThrower, but that ended up forcing me to make cmdRollP basically a large clone function of cmdRoll. Not the most elegant.