### PR TITLE
Maybe fix characters becoming unselectable

### DIFF
--- a/core/src/packet/packet_cc.cpp
+++ b/core/src/packet/packet_cc.cpp
@@ -23,6 +23,11 @@ void PacketCC::handlePacket(AreaData *area, AOClient &client) const
 {
     Q_UNUSED(area)
 
+    if (!client.hasJoined()) {
+        //No character selecting when you aren't joined.
+        return;
+    }
+
     bool argument_ok;
     int l_selected_char_id = m_content[1].toInt(&argument_ok);
     if (!argument_ok) {

--- a/core/src/packet/packet_cc.cpp
+++ b/core/src/packet/packet_cc.cpp
@@ -24,7 +24,7 @@ void PacketCC::handlePacket(AreaData *area, AOClient &client) const
     Q_UNUSED(area)
 
     if (!client.hasJoined()) {
-        //No character selecting when you aren't joined.
+        // No character selecting when you aren't joined.
         return;
     }
 


### PR DESCRIPTION
Prevents early-selection while the client is still in the handshake.