### PR TITLE
Check for doubleposts per client, not per area

### DIFF
--- a/core/include/packet/packet_ms.h
+++ b/core/include/packet/packet_ms.h
@@ -13,6 +13,6 @@ class PacketMS : public AOPacket
 
   private:
     AOPacket *validateIcPacket(AOClient &client) const;
-    QRegularExpressionMatch regexTestimonyJumpCommand(QString message) const;
+    QRegularExpressionMatch isTestimonyJumpCommand(QString message) const;
 };
 #endif

--- a/core/include/packet/packet_ms.h
+++ b/core/include/packet/packet_ms.h
@@ -13,5 +13,6 @@ class PacketMS : public AOPacket
 
   private:
     AOPacket *validateIcPacket(AOClient &client) const;
+    QRegularExpressionMatch regexTestimonyJumpCommand(QString message) const;
 };
 #endif

--- a/core/src/packet/packet_ms.cpp
+++ b/core/src/packet/packet_ms.cpp
@@ -125,7 +125,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
 
     // Doublepost prevention. Has to ignore blankposts and testimony commands.
     QString l_incoming_msg = client.dezalgo(l_incoming_args[4].toString().trimmed());
-    QRegularExpressionMatch match = regexTestimonyJumpCommand(client.decodeMessage(l_args[4]));
+    QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(l_args[4]));
     bool msg_is_testimony_cmd = (match.hasMatch() || l_incoming_msg == ">" || l_incoming_msg == "<");
     if (!client.m_last_message.isEmpty()           // If the last message you sent isn't empty,
         && l_incoming_msg == client.m_last_message // and it matches the one you're sending,
@@ -405,7 +405,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
                 client.sendServerMessage("First statement reached.");
             }
         }
-        QRegularExpressionMatch match = regexTestimonyJumpCommand(client.decodeMessage(l_args[4])); // Get rid of that pesky encoding, then do the fun part
+        QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(l_args[4])); // Get rid of that pesky encoding, then do the fun part
         if (match.hasMatch()) {
             client.m_pos = "wit";
             auto l_statement = area->jumpToStatement(match.captured("int").toInt());

--- a/core/src/packet/packet_ms.cpp
+++ b/core/src/packet/packet_ms.cpp
@@ -127,10 +127,10 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     QString l_incoming_msg = client.dezalgo(l_incoming_args[4].toString().trimmed());
     QRegularExpressionMatch match = regexTestimonyJumpCommand(client.decodeMessage(l_args[4]));
     bool msg_is_testimony_cmd = (match.hasMatch() || l_incoming_msg == ">" || l_incoming_msg == "<");
-    if (!client.m_last_message.isEmpty()             // If the last message you sent isn't empty,
-        && l_incoming_msg == client.m_last_message   // and it matches the one you're sending,
-        && !msg_is_testimony_cmd)                    // and it's not a testimony command,
-        return l_invalid;                            // get it the hell outta here!
+    if (!client.m_last_message.isEmpty()           // If the last message you sent isn't empty,
+        && l_incoming_msg == client.m_last_message // and it matches the one you're sending,
+        && !msg_is_testimony_cmd)                  // and it's not a testimony command,
+        return l_invalid;                          // get it the hell outta here!
 
     if (l_incoming_msg == "" && area->blankpostingAllowed() == false) {
         client.sendServerMessage("Blankposting has been forbidden in this area.");

--- a/core/src/packet/packet_ms.cpp
+++ b/core/src/packet/packet_ms.cpp
@@ -434,7 +434,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     return PacketFactory::createPacket("MS", l_args);
 }
 
-QRegularExpressionMatch PacketMS::regexTestimonyJumpCommand(QString message) const
+QRegularExpressionMatch PacketMS::isTestimonyJumpCommand(QString message) const
 {
     // *sigh* slightly too chunky and needed slightly
     // too often to justify not making this a helper

--- a/core/src/packet/packet_ms.cpp
+++ b/core/src/packet/packet_ms.cpp
@@ -124,7 +124,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         return l_invalid;
 
     QString l_incoming_msg = client.dezalgo(l_incoming_args[4].toString().trimmed());
-    if (!area->lastICMessage().isEmpty() && l_incoming_msg == area->lastICMessage()[4] && l_incoming_msg != "")
+    if (!client.m_last_message.isEmpty() && l_incoming_msg == client.m_last_message && l_incoming_msg != "")
         return l_invalid;
 
     if (l_incoming_msg == "" && area->blankpostingAllowed() == false) {


### PR DESCRIPTION
Doing it per area neutered a lot of jokes, and was kind of awkward. Per client feels a lot more natural, and still serves to prevent spam about as well.