### PR TITLE
Fix CPU core maxing out, esp. on Linux and bump version for hotfix

### DIFF
--- a/akashi/main.cpp
+++ b/akashi/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
     QCoreApplication::setApplicationName("akashi");
-    QCoreApplication::setApplicationVersion("honeydew (1.8)");
+    QCoreApplication::setApplicationVersion("honeydew hotfix (1.8.1)");
     std::atexit(cleanup);
 
     // Verify server configuration is sound.

--- a/core/src/area_data.cpp
+++ b/core/src/area_data.cpp
@@ -326,6 +326,7 @@ bool AreaData::isShoutAllowed() const
 void AreaData::startMessageFloodguard(int f_duration)
 {
     m_can_send_ic_messages = false;
+    m_message_floodguard_timer->setSingleShot(true);
     m_message_floodguard_timer->start(f_duration);
 }
 

--- a/core/src/packet/packet_mc.cpp
+++ b/core/src/packet/packet_mc.cpp
@@ -87,6 +87,10 @@ void PacketMC::handlePacket(AreaData *area, AOClient &client) const
         QString l_area = client.getServer()->getAreaName(i);
         if (l_area == l_argument) {
             client.changeArea(i);
+            QString tempname = client.m_current_char;
+            if (!client.m_showname.isEmpty())
+                tempname = client.m_showname;
+            client.sendServerMessageArea(tempname + " entered the area.");
             break;
         }
     }

--- a/core/src/packet/packet_mc.cpp
+++ b/core/src/packet/packet_mc.cpp
@@ -87,10 +87,6 @@ void PacketMC::handlePacket(AreaData *area, AOClient &client) const
         QString l_area = client.getServer()->getAreaName(i);
         if (l_area == l_argument) {
             client.changeArea(i);
-            QString tempname = client.m_current_char;
-            if (!client.m_showname.isEmpty())
-                tempname = client.m_showname;
-            client.sendServerMessageArea(tempname + " entered the area.");
             break;
         }
     }

--- a/core/src/server.cpp
+++ b/core/src/server.cpp
@@ -144,6 +144,7 @@ void Server::start()
 
     // Rate-Limiter for IC-Chat
     m_message_floodguard_timer = new QTimer(this);
+    m_message_floodguard_timer->setSingleShot(true);
     connect(m_message_floodguard_timer, &QTimer::timeout, this, &Server::allowMessage);
 
     // Prepare player IDs and reference hash.


### PR DESCRIPTION
Floodguard timers were running repeatedly, causing CPU usage to spike in the main event loop.

Fixes #315 