### PR TITLE
Allow those with the CM perm to play music

### DIFF
--- a/core/src/commands/music.cpp
+++ b/core/src/commands/music.cpp
@@ -34,7 +34,8 @@ void AOClient::cmdPlay(int argc, QStringList argv)
         return;
     }
     AreaData *l_area = server->getAreaById(m_current_area);
-    if (!l_area->owners().contains(m_id) && !l_area->isPlayEnabled()) { // Make sure we have permission to play music
+    const ACLRole l_role = server->getACLRolesHandler()->getRoleById(m_acl_role_id);
+    if (!l_area->owners().contains(m_id) && !l_area->isPlayEnabled() && !l_role.checkPermission(ACLRole::CM)) { // Make sure we have permission to play music
         sendServerMessage("Free music play is disabled in this area.");
         return;
     }


### PR DESCRIPTION
regardless of what the area thinks. a SUPER user not being able to play a song is a bit odd

solution is quick and dirty (I literally just copied code from elsewhere). there's likely a better way to do this