### PR TITLE
QRegExp to QRegularExpression and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Requires Qt >= 5.10, and Qt websockets
 
 **Ubuntu 20.04/22.04** - Ubuntu 18.04 or older are not supported.
 ```
-   sudo apt install build-essential qt5-default libqt5websockets5-dev
+   sudo apt install build-essential qtbase5-dev qt5-qmake qttools5-dev qttools5-dev-tools libqt5websockets5-dev
    git clone https://github.com/AttorneyOnline/akashi
    cd akashi
-   qmake && make
+   qmake project-akashi.pro && make
 ```
 
 # Contributors

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -2,8 +2,9 @@
 #include "config_manager.h"
 #include "packet/packet_factory.h"
 #include "server.h"
-#include <QRegularExpression>
+
 #include <QDebug>
+#include <QRegularExpression>
 
 PacketMS::PacketMS(QStringList &contents) :
     AOPacket(contents)

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -2,7 +2,7 @@
 #include "config_manager.h"
 #include "packet/packet_factory.h"
 #include "server.h"
-
+#include <QRegularExpression>
 #include <QDebug>
 
 PacketMS::PacketMS(QStringList &contents) :
@@ -153,7 +153,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     }
 
     if (client.m_is_disemvoweled) {
-        QString l_disemvoweled_message = l_incoming_msg.remove(QRegExp("[AEIOUaeiou]"));
+        QString l_disemvoweled_message = l_incoming_msg.remove(QRegularExpression("[AEIOUaeiou]"));
         l_incoming_msg = l_disemvoweled_message;
     }
 


### PR DESCRIPTION
One instance of QRegExp made the compiler crash when trying to build Akashi with Qt6. Also, the README.md build instructions were outdated, new ones were provided to me by Salanto.