### PR TITLE
Fix icon path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# akashi <img src="https://github.com/AttorneyOnline/akashi/blob/master/akashi/resource/icon/256.png" width=30 height=30>
+# akashi <img src="https://github.com/AttorneyOnline/akashi/blob/master/resource/icon/256.png" width=30 height=30>
 A C++ server for Attorney Online 2<br><br>
 ![Code Format and Build](https://github.com/AttorneyOnline/akashi/actions/workflows/main.yml/badge.svg?event=push) [![Codecov branch](https://img.shields.io/codecov/c/gh/AttorneyOnline/akashi/master)](https://app.codecov.io/gh/AttorneyOnline/akashi) [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/AttorneyOnline/akashi/graphs/commit-activity) ![GitHub](https://img.shields.io/github/license/AttorneyOnline/akashi?color=blue)<br>
 


### PR DESCRIPTION
Path changed in https://github.com/AttorneyOnline/akashi/commit/040f5a32161ba241832d15d514316739ebf67986#diff-ae8d834c42c9d4ecb756f7c94dfb45466562c5b20ced9f64c6fdf313f0b28aa2, updating here.