### PR TITLE
Mark AFK players in the player list

### DIFF
--- a/core.pro
+++ b/core.pro
@@ -25,7 +25,7 @@ DESTDIR = $$PWD/bin
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # Enable this to print network messages to the console
-DEFINES += NET_DEBUG
+# DEFINES += NET_DEBUG
 
 INCLUDEPATH += src
 

--- a/core.pro
+++ b/core.pro
@@ -25,7 +25,7 @@ DESTDIR = $$PWD/bin
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 # Enable this to print network messages to the console
-# DEFINES += NET_DEBUG
+DEFINES += NET_DEBUG
 
 INCLUDEPATH += src
 

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -556,8 +556,10 @@ bool AOClient::isSpectator() const
 
 void AOClient::onAfkTimeout()
 {
-    if (!m_is_afk)
+    if (!m_is_afk) {
         sendServerMessage("You are now AFK.");
+        setName(name() + " [AFK]");
+    }
     m_is_afk = true;
 }
 

--- a/src/aoclient.cpp
+++ b/src/aoclient.cpp
@@ -198,6 +198,9 @@ void AOClient::handlePacket(AOPacket *packet)
         if (m_is_afk)
             sendServerMessage("You are no longer AFK.");
         m_is_afk = false;
+        if (characterName().endsWith(" [AFK]")) {
+            setCharacterName(characterName().remove(" [AFK]"));
+        }
         m_afk_timer->start(ConfigManager::afkTimeout() * 1000);
     }
 
@@ -558,7 +561,7 @@ void AOClient::onAfkTimeout()
 {
     if (!m_is_afk) {
         sendServerMessage("You are now AFK.");
-        setName(name() + " [AFK]");
+        setCharacterName(characterName() + " [AFK]");
     }
     m_is_afk = true;
 }

--- a/src/commands/command_helper.cpp
+++ b/src/commands/command_helper.cpp
@@ -64,8 +64,6 @@ QStringList AOClient::buildAreaList(int area_idx)
                 char_entry.insert(0, "[CM] ");
             if (m_authenticated)
                 char_entry += " (" + l_client->getIpid() + "): " + l_client->name();
-            if (l_client->m_is_afk)
-                char_entry += " [AFK]";
             entries.append(char_entry);
         }
     }

--- a/src/commands/messaging.cpp
+++ b/src/commands/messaging.cpp
@@ -387,6 +387,7 @@ void AOClient::cmdAfk(int argc, QStringList argv)
 
     m_is_afk = true;
     sendServerMessage("You are now AFK.");
+    setCharacterName(characterName() + " [AFK]");
 }
 
 void AOClient::cmdCharCurse(int argc, QStringList argv)


### PR DESCRIPTION
This is done by setting internal player name to include "[AFK]" so that it appears in the player list. When the player next chats, the server will notice their name no longer contains "[AFK]" and automatically update it again.

Also removed the marker from /getarea since this would make it redundant.