### PR TITLE
Add hints in testimony, add pause alias.

### DIFF
--- a/bin/config_sample/command_extensions.ini
+++ b/bin/config_sample/command_extensions.ini
@@ -90,3 +90,6 @@ aliases = jukeboxskip
 
 [play_ambience]
 aliases = playambience playa
+
+[pause]
+aliases = end

--- a/src/commands/casing.cpp
+++ b/src/commands/casing.cpp
@@ -113,12 +113,12 @@ void AOClient::cmdTestify(int argc, QStringList argv)
 
     AreaData *l_area = server->getAreaById(areaId());
     if (l_area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING) {
-        sendServerMessage("Testimony recording is already in progress. Please stop it before starting a new one.");
+        sendServerMessage("Testimony recording is already in progress. Please stop it with /end before starting a new one.");
     }
     else {
         clearTestimony();
         l_area->setTestimonyRecording(AreaData::TestimonyRecording::RECORDING);
-        sendServerMessage("Started testimony recording.");
+        sendServerMessage("Started testimony recording. Your next IC message will be a title. Use /end to stop recording.");
     }
 }
 
@@ -135,9 +135,9 @@ void AOClient::cmdExamine(int argc, QStringList argv)
         return;
     }
     if (l_area->testimonyRecording() == AreaData::TestimonyRecording::PLAYBACK)
-        sendServerMessage("Unable to examine while another examination is running");
+        sendServerMessage("An examination is already running. Use /testimony to view the testimony.");
     else
-        sendServerMessage("Unable to start replay without prior examination.");
+        sendServerMessage("Unable to start replay without prior testimony. Use /testify to start. You can load a testimony with /loadtestimony.");
 }
 
 void AOClient::cmdTestimony(int argc, QStringList argv)
@@ -182,7 +182,7 @@ void AOClient::cmdUpdateStatement(int argc, QStringList argv)
     Q_UNUSED(argv);
 
     server->getAreaById(areaId())->setTestimonyRecording(AreaData::TestimonyRecording::UPDATE);
-    sendServerMessage("The next IC-Message will replace the last displayed replay message.");
+    sendServerMessage("The next IC-Message will replace the currently selected testimony line.");
 }
 
 void AOClient::cmdPauseTestimony(int argc, QStringList argv)
@@ -193,7 +193,7 @@ void AOClient::cmdPauseTestimony(int argc, QStringList argv)
     AreaData *l_area = server->getAreaById(areaId());
     l_area->setTestimonyRecording(AreaData::TestimonyRecording::STOPPED);
     server->broadcast(PacketFactory::createPacket("RT", {"testimony1", "1"}), areaId());
-    sendServerMessage("Testimony has been stopped.");
+    sendServerMessage("Testimony has been stopped. Use /examine to begin cross-examination.");
 }
 
 void AOClient::cmdAddStatement(int argc, QStringList argv)

--- a/src/commands/casing.cpp
+++ b/src/commands/casing.cpp
@@ -140,10 +140,9 @@ void AOClient::cmdExamine(int argc, QStringList argv)
         }
     }
     else {
-       sendServerMessage("Unable to start replay without prior testimony. Use /testify to start Or load a testimony with /loadtestimony.");
+        sendServerMessage("Unable to start replay without prior testimony. Use /testify to start Or load a testimony with /loadtestimony.");
     }
 }
-
 
 void AOClient::cmdTestimony(int argc, QStringList argv)
 {

--- a/src/commands/casing.cpp
+++ b/src/commands/casing.cpp
@@ -129,16 +129,21 @@ void AOClient::cmdExamine(int argc, QStringList argv)
 
     AreaData *l_area = server->getAreaById(areaId());
     if (l_area->testimony().size() - 1 > 0) {
-        l_area->restartTestimony();
-        server->broadcast(PacketFactory::createPacket("RT", {"testimony2", "0"}), areaId());
-        server->broadcast(PacketFactory::createPacket("MS", {l_area->testimony()[0]}), areaId());
-        return;
+        if (l_area->testimonyRecording() == AreaData::TestimonyRecording::PLAYBACK) {
+            sendServerMessage("An examination is already running. Use /testimony to view the testimony.");
+        }
+        else {
+            l_area->restartTestimony();
+            server->broadcast(PacketFactory::createPacket("RT", {"testimony2", "0"}), areaId());
+            server->broadcast(PacketFactory::createPacket("MS", {l_area->testimony()[0]}), areaId());
+            return;
+        }
     }
-    if (l_area->testimonyRecording() == AreaData::TestimonyRecording::PLAYBACK)
-        sendServerMessage("An examination is already running. Use /testimony to view the testimony.");
-    else
-        sendServerMessage("Unable to start replay without prior testimony. Use /testify to start. You can load a testimony with /loadtestimony.");
+    else {
+       sendServerMessage("Unable to start replay without prior testimony. Use /testify to start Or load a testimony with /loadtestimony.");
+    }
 }
+
 
 void AOClient::cmdTestimony(int argc, QStringList argv)
 {

--- a/src/commands/casing.cpp
+++ b/src/commands/casing.cpp
@@ -118,7 +118,7 @@ void AOClient::cmdTestify(int argc, QStringList argv)
     else {
         clearTestimony();
         l_area->setTestimonyRecording(AreaData::TestimonyRecording::RECORDING);
-        sendServerMessage("Started testimony recording. Your next IC message will be a title. Use /end to stop recording.");
+        sendServerMessage("Started testimony recording. The next IC message will be a title. Use /end to stop recording.");
     }
 }
 


### PR DESCRIPTION
end is most commonly used, provides more clarity that the testimony has "stopped" and further testimony is via /add and /update.