### PR TITLE
Convert the MS packet's contents to JSON

### DIFF
--- a/core.pro
+++ b/core.pro
@@ -79,7 +79,8 @@ SOURCES += \
   src/packet/packet_rm.cpp \
   src/packet/packet_rt.cpp \
   src/packet/packet_setcase.cpp \
-  src/packet/packet_zz.cpp
+  src/packet/packet_zz.cpp \
+  src/packet/data/msdata.cpp
 
 HEADERS += src/aoclient.h \
   src/acl_roles_handler.h \
@@ -124,4 +125,5 @@ HEADERS += src/aoclient.h \
   src/packet/packet_rm.h \
   src/packet/packet_rt.h \
   src/packet/packet_setcase.h \
-  src/packet/packet_zz.h
+  src/packet/packet_zz.h \
+  src/packet/data/msdata.h

--- a/src/aoclient.h
+++ b/src/aoclient.h
@@ -576,7 +576,7 @@ class AOClient : public QObject
      * @details This used to be just a plain number ranging from -100 to 100, but then Crystal mangled it by building some extra data into it.
      * Cheers, love.
      */
-    QPair<qint32, qint32> m_offset{0, 0};
+    ms2::OffsetData m_offset{0, 0};
 
     /**
      * @brief The last flipped state of the client.

--- a/src/aoclient.h
+++ b/src/aoclient.h
@@ -29,6 +29,7 @@
 #include "acl_roles_handler.h"
 #include "network/aopacket.h"
 #include "network/network_socket.h"
+#include "packet/data/msdata.h"
 
 class AreaData;
 class DBManager;
@@ -485,14 +486,14 @@ class AOClient : public QObject
      *
      * @param packet The MS-Packet being recorded with their color changed to green.
      */
-    void addStatement(QStringList packet);
+    void addStatement(ms2::OldMSFlatData packet);
 
     /**
      * @brief Updates the currently displayed IC-Message with the next one send
      * @param packet The IC-Message that will overwrite the currently stored one.
      * @return Returns the updated IC-Message to be send to the other users. It also changes the color to green.
      */
-    QStringList updateStatement(QStringList packet);
+    ms2::OldMSFlatData updateStatement(ms2::OldMSFlatData packet);
 
     /**
      * @brief Convenience function to generate a random integer number between the given minimum and maximum values.
@@ -575,12 +576,12 @@ class AOClient : public QObject
      * @details This used to be just a plain number ranging from -100 to 100, but then Crystal mangled it by building some extra data into it.
      * Cheers, love.
      */
-    QString m_offset = "";
+    QPair<qint32, qint32> m_offset{0, 0};
 
     /**
      * @brief The last flipped state of the client.
      */
-    QString m_flipping = "";
+    bool m_flipping = false;
 
     /**
      * @brief The last reported position of the client.

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -16,6 +16,7 @@
 //    along with this program.  If not, see <https://www.gnu.org/licenses/>.        //
 //////////////////////////////////////////////////////////////////////////////////////
 
+#include <QJsonDocument>
 #include <algorithm>
 
 #include "area_data.h"
@@ -364,14 +365,14 @@ void AreaData::toggleImmediate()
     m_forceImmediate = !m_forceImmediate;
 }
 
-const QStringList &AreaData::lastICMessage() const
+const ms2::OldMSFlatData &AreaData::lastICMessage() const
 {
     return m_lastICMessage;
 }
 
 void AreaData::updateLastICMessage(const QStringList &f_lastMessage_r)
 {
-    m_lastICMessage = f_lastMessage_r;
+    ms2::OldMSFlatData::fromJson(QJsonDocument::fromJson(f_lastMessage_r.at(0).toUtf8()).object(), m_lastICMessage);
 }
 
 QStringList AreaData::judgelog() const

--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -393,18 +393,18 @@ int AreaData::statement() const
     return m_statement;
 }
 
-void AreaData::recordStatement(const QStringList &f_newStatement_r)
+void AreaData::recordStatement(const ms2::OldMSFlatData &f_newStatement_r)
 {
     ++m_statement;
     m_testimony.append(f_newStatement_r);
 }
 
-void AreaData::addStatement(int f_position, const QStringList &f_newStatement_r)
+void AreaData::addStatement(int f_position, const ms2::OldMSFlatData &f_newStatement_r)
 {
     m_testimony.insert(f_position, f_newStatement_r);
 }
 
-void AreaData::replaceStatement(int f_position, const QStringList &f_newStatement_r)
+void AreaData::replaceStatement(int f_position, const ms2::OldMSFlatData &f_newStatement_r)
 {
     m_testimony.replace(f_position, f_newStatement_r);
 }
@@ -415,7 +415,7 @@ void AreaData::removeStatement(int f_position)
     --m_statement;
 }
 
-QPair<QStringList, AreaData::TestimonyProgress> AreaData::jumpToStatement(int f_position)
+QPair<ms2::OldMSFlatData, AreaData::TestimonyProgress> AreaData::jumpToStatement(int f_position)
 {
     m_statement = f_position;
 
@@ -432,7 +432,7 @@ QPair<QStringList, AreaData::TestimonyProgress> AreaData::jumpToStatement(int f_
     }
 }
 
-const QVector<QStringList> &AreaData::testimony() const
+const QVector<ms2::OldMSFlatData> &AreaData::testimony() const
 {
     return m_testimony;
 }

--- a/src/area_data.h
+++ b/src/area_data.h
@@ -851,7 +851,7 @@ class AreaData : public QObject
      *
      * @return See short description.
      */
-    const QStringList &lastICMessage() const;
+    const ms2::OldMSFlatData &lastICMessage() const;
 
     /**
      * @brief Updates the last IC message sent in the area.
@@ -1185,7 +1185,7 @@ class AreaData : public QObject
     /**
      * @brief The last IC packet sent in an area.
      */
-    QStringList m_lastICMessage;
+    ms2::OldMSFlatData m_lastICMessage;
 
     /**
      * @brief Whether or not to force immediate text processing in this area.

--- a/src/area_data.h
+++ b/src/area_data.h
@@ -27,6 +27,7 @@
 #include <QTimer>
 
 #include "network/aopacket.h"
+#include "packet/data/msdata.h"
 
 class ConfigManager;
 class Logger;
@@ -771,7 +772,7 @@ class AreaData : public QObject
      *
      * @note Unlike most other getters, this one returns a reference, as it is expected to be used frequently.
      */
-    const QVector<QStringList> &testimony() const;
+    const QVector<ms2::OldMSFlatData> &testimony() const;
 
     /**
      * @brief Returns the index of the currently examined statement in the testimony.
@@ -785,7 +786,7 @@ class AreaData : public QObject
      *
      * @param f_newStatement_r The IC message packet to append to the testimony vector.
      */
-    void recordStatement(const QStringList &f_newStatement_r);
+    void recordStatement(const ms2::OldMSFlatData &f_newStatement_r);
 
     /**
      * @brief Adds a statement into the testimony to a given position.
@@ -793,7 +794,7 @@ class AreaData : public QObject
      * @param f_position The index to insert the statement to.
      * @param f_newStatement_r The IC message packet to insert.
      */
-    void addStatement(int f_position, const QStringList &f_newStatement_r);
+    void addStatement(int f_position, const ms2::OldMSFlatData &f_newStatement_r);
 
     /**
      * @brief Replaces an already existing statement in the testimony in a given position with a new one.
@@ -801,7 +802,7 @@ class AreaData : public QObject
      * @param f_position The index of the statement to replace.
      * @param f_newStatement_r The IC message packet to insert in the old one's stead.
      */
-    void replaceStatement(int f_position, const QStringList &f_newStatement_r);
+    void replaceStatement(int f_position, const ms2::OldMSFlatData &f_newStatement_r);
 
     /**
      * @brief Removes a statement from the testimony at a given position, and moves the statement index one backward.
@@ -821,10 +822,10 @@ class AreaData : public QObject
      * @param f_position The index to jump to.
      *
      * @return A pair of values:
-     * * First, a `QStringList` that is the packet of the statement that was advanced to.
+     * * First, a `ms2::OldMSFlatData` that is the packet of the statement that was advanced to.
      * * Then, a `TestimonyProgress` value that describes how the advancement happened.
      */
-    QPair<QStringList, AreaData::TestimonyProgress> jumpToStatement(int f_position);
+    QPair<ms2::OldMSFlatData, AreaData::TestimonyProgress> jumpToStatement(int f_position);
 
     /**
      * @brief Returns a copy of the judgelog in the area.
@@ -1171,7 +1172,7 @@ class AreaData : public QObject
      */
     TestimonyRecording m_testimonyRecording;
 
-    QVector<QStringList> m_testimony; //!< Vector of all statements saved. Index 0 is always the title of the testimony.
+    QVector<ms2::OldMSFlatData> m_testimony; //!< Vector of all statements saved. Index 0 is always the title of the testimony.
     int m_statement;                  //!< Keeps track of the currently played statement.
 
     /**

--- a/src/area_data.h
+++ b/src/area_data.h
@@ -1173,7 +1173,7 @@ class AreaData : public QObject
     TestimonyRecording m_testimonyRecording;
 
     QVector<ms2::OldMSFlatData> m_testimony; //!< Vector of all statements saved. Index 0 is always the title of the testimony.
-    int m_statement;                  //!< Keeps track of the currently played statement.
+    int m_statement;                         //!< Keeps track of the currently played statement.
 
     /**
      * @brief The judgelog of an area.

--- a/src/network/aopacket.cpp
+++ b/src/network/aopacket.cpp
@@ -41,6 +41,8 @@
 #include "packet/packet_setcase.h"
 #include "packet/packet_zz.h"
 
+#include <QJsonDocument>
+
 AOPacket::AOPacket(QStringList p_contents) :
     m_content(p_contents),
     m_escaped(false)
@@ -76,6 +78,19 @@ QByteArray AOPacket::toUtf8()
 void AOPacket::setContentField(int f_content_index, QString f_content_data)
 {
     m_content[f_content_index] = f_content_data;
+}
+
+void AOPacket::setJsonContentField(const QString &f_key, const QString &f_value)
+{
+    QJsonParseError l_error{};
+    auto l_jsonDocument = QJsonDocument::fromJson(m_content.at(0).toUtf8(), &l_error);
+    auto l_jsonObject = l_jsonDocument.object();
+
+    if (l_error.error == QJsonParseError::ParseError::NoError && l_jsonObject[f_key].isString()) {
+        l_jsonObject[f_key] = f_value;
+    }
+
+    m_content = QStringList{QJsonDocument{l_jsonObject}.toJson(QJsonDocument::Compact)};
 }
 
 void AOPacket::escapeContent()

--- a/src/network/aopacket.h
+++ b/src/network/aopacket.h
@@ -72,6 +72,11 @@ class AOPacket
     void setContentField(int f_content_index, QString f_content_data);
 
     /**
+     * @brief As setContentField, but for packets that use JSON as their data.
+     */
+    void setJsonContentField(const QString &f_key, const QString &f_value);
+
+    /**
      * @brief Escapes the content of the packet using AO2's escape codes.
      *
      * @see https://github.com/AttorneyOnline/docs/blob/master/AO%20Documentation/docs/development/network.md#escape-codes

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -1,0 +1,218 @@
+#include "packet/data/msdata.h"
+
+#include <QJsonArray>
+
+bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_data)
+{
+    if (const QJsonValue v = f_json["desk_mod"]; v.isDouble())
+        f_data.m_desk_mod = DeskMod(v.toInt());
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["preanim"]; v.isString())
+        f_data.m_preanim = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["char_name"]; v.isString())
+        f_data.m_char_name = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["emote"]; v.isString())
+        f_data.m_emote = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["message_text"]; v.isString())
+        f_data.m_message_text = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["side"]; v.isString()) {
+        f_data.m_side = v.toString();
+        f_data.m_side.replace("../", "").replace("..\\", "");
+    }
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["sfx_name"]; v.isString())
+        f_data.m_sfx_name = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["emote_mod"]; v.isDouble())
+        f_data.m_emote_mod = EmoteMod(v.toInt());
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["char_id"]; v.isDouble())
+        f_data.m_char_id = v.toInt();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["sfx_delay"]; v.isDouble())
+        f_data.m_sfx_delay = v.toInt();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["objection_mod"]; v.isDouble()) {
+        f_data.m_objection_mod = ObjectionMod(v.toInt());
+        if (f_data.m_objection_mod == ObjectionMod::Custom) {
+            if (const QJsonValue v = f_json["objection_custom"]; v.isString())
+                f_data.m_objection_custom = v.toString();
+        }
+    }
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["evidence"]; v.isDouble())
+        f_data.m_evidence = v.toInt();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["flip"]; v.isBool())
+        f_data.m_flip = v.toBool();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["realisation"]; v.isBool())
+        f_data.m_realisation = v.toBool();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["text_colour"]; v.isDouble())
+        f_data.m_text_colour = v.toInt();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["showname"]; v.isString())
+        f_data.m_showname = v.toString();
+
+    if (const QJsonValue v = f_json["other_charid"]; v.isDouble())
+        f_data.m_other_charid = v.toInt();
+
+    if (const QJsonValue v = f_json["other_name"]; v.isString())
+        f_data.m_other_name = v.toString();
+
+    if (const QJsonValue v = f_json["self_x_offset"]; v.isDouble())
+        f_data.m_self_x_offset = v.toInt();
+
+    if (const QJsonValue v = f_json["self_y_offset"]; v.isDouble())
+        f_data.m_self_y_offset = v.toInt();
+
+    if (const QJsonValue v = f_json["other_x_offset"]; v.isDouble())
+        f_data.m_other_x_offset = v.toInt();
+
+    if (const QJsonValue v = f_json["other_y_offset"]; v.isDouble())
+        f_data.m_other_y_offset = v.toInt();
+
+    if (const QJsonValue v = f_json["other_flip"]; v.isBool())
+        f_data.m_other_flip = v.toBool();
+
+    if (const QJsonValue v = f_json["immediate"]; v.isBool())
+        f_data.m_immediate = v.toBool();
+
+    if (const QJsonValue v = f_json["sfx_looping"]; v.isBool())
+        f_data.m_sfx_looping = v.toBool();
+
+    if (const QJsonValue v = f_json["screenshake"]; v.isBool())
+        f_data.m_screenshake = v.toBool();
+
+    if (const QJsonValue v = f_json["frames_shake"]; v.isArray()) {
+        const QJsonArray frames = v.toArray();
+        f_data.m_frames_shake.reserve(frames.size());
+        for (const QJsonValue &frame : frames) {
+            if (frame.isDouble())
+                f_data.m_frames_shake.append(frame.toInt());
+        }
+    }
+
+    if (const QJsonValue v = f_json["frames_realisation"]; v.isArray()) {
+        const QJsonArray frames = v.toArray();
+        f_data.m_frames_realisation.reserve(frames.size());
+        for (const QJsonValue &frame : frames) {
+            if (frame.isDouble())
+                f_data.m_frames_realisation.append(frame.toInt());
+        }
+    }
+
+    if (const QJsonValue v = f_json["frames_sfx"]; v.isArray()) {
+        const QJsonArray frames = v.toArray();
+        f_data.m_frames_sfx.reserve(frames.size());
+        for (const QJsonValue &frame : frames) {
+            if (frame.isDouble())
+                f_data.m_frames_sfx.append(frame.toInt());
+        }
+    }
+
+    if (const QJsonValue v = f_json["additive"]; v.isBool())
+        f_data.m_additive = v.toBool();
+
+    if (const QJsonValue v = f_json["effect"]; v.isString())
+        f_data.m_effect = v.toString();
+
+    if (const QJsonValue v = f_json["blips"]; v.isString())
+        f_data.m_blips = v.toString();
+
+    return true;
+}
+
+QJsonObject ms2::OldMSFlatData::toJson() const
+{
+    QJsonObject json;
+
+    json["desk_mod"] = static_cast<qint32>(m_desk_mod);
+    json["preanim"] = m_preanim;
+    json["char_name"] = m_char_name;
+    json["emote"] = m_emote;
+    json["message_text"] = m_message_text;
+    json["side"] = m_side;
+    json["sfx_name"] = m_sfx_name;
+    json["emote_mod"] = static_cast<qint32>(m_emote_mod);
+    json["char_id"] = m_char_id;
+    json["sfx_delay"] = m_sfx_delay;
+    json["objection_mod"] = static_cast<qint32>(m_objection_mod);
+    json["objection_custom"] = m_objection_custom;
+    json["evidence"] = m_evidence;
+    json["flip"] = m_flip;
+    json["realisation"] = m_realisation;
+    json["text_color"] = m_text_colour;
+    json["showname"] = m_showname;
+    json["other_charid"] = m_other_charid;
+    json["other_name"] = m_other_name;
+    json["other_emote"] = m_other_emote;
+    json["self_x_offset"] = m_self_x_offset;
+    json["self_y_offset"] = m_self_y_offset;
+    json["other_x_offset"] = m_other_x_offset;
+    json["other_y_offset"] = m_other_y_offset;
+    json["other_flip"] = m_other_flip;
+    json["immediate"] = m_immediate;
+    json["sfx_looping"] = m_sfx_looping;
+    json["screenshake"] = m_screenshake;
+
+    {
+        QJsonArray frameShakeArray;
+        for (const qint32 frame : m_frames_shake)
+            frameShakeArray.append(frame);
+        json["frames_shake"] = frameShakeArray;
+    }
+    {
+        QJsonArray frameRealisationArray;
+        for (const qint32 frame : m_frames_realisation)
+            frameRealisationArray.append(frame);
+        json["frames_realisation"] = frameRealisationArray;
+    }
+    {
+        QJsonArray frameSfxArray;
+        for (const qint32 frame : m_frames_sfx)
+            frameSfxArray.append(frame);
+        json["frames_sfx"] = frameSfxArray;
+    }
+
+    json["additive"] = m_additive;
+    json["effect"] = m_effect;
+    json["blips"] = m_blips;
+
+    return json;
+}

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -160,6 +160,9 @@ bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_da
     if (const QJsonValue v = f_json["blips"]; v.isString())
         f_data.m_blips = v.toString();
 
+    if (const QJsonValue v = f_json["slide"]; v.isBool())
+        f_data.m_slide = v.toBool();
+
     return true;
 }
 
@@ -218,6 +221,7 @@ QJsonObject ms2::OldMSFlatData::toJson() const
     json["additive"] = m_additive;
     json["effect"] = m_effect;
     json["blips"] = m_blips;
+    json["slide"] = m_slide;
 
     return json;
 }

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -139,9 +139,7 @@ bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_da
         f_data.m_frames_sfx.reserve(frames.size());
         for (const QJsonValue &frame : frames) {
             FrameData l_data{};
-            if (frame.isObject() &&
-                FrameData::fromJson(frame.toObject(), l_data) &&
-                !l_data.m_value.isEmpty())
+            if (frame.isObject() && FrameData::fromJson(frame.toObject(), l_data) && !l_data.m_value.isEmpty())
                 f_data.m_frames_sfx.append(l_data);
         }
     }
@@ -286,6 +284,11 @@ bool ms2::OtherData::fromJson(const QJsonObject &f_json, OtherData &f_data)
 
     if (const QJsonValue v = f_json["name"]; v.isString())
         f_data.m_name = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["emote"]; v.isString())
+        f_data.m_emote = v.toString();
     else
         return false;
 

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -185,7 +185,7 @@ QJsonObject ms2::OldMSFlatData::toJson() const
     json["evidence"] = m_evidence;
     json["flip"] = m_flip;
     json["realisation"] = m_realisation;
-    json["text_color"] = m_text_colour;
+    json["text_colour"] = m_text_colour;
     json["showname"] = m_showname;
     json["other"] = m_other.toJson();
     json["offset"] = m_offset.toJson();

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -95,17 +95,21 @@ bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_da
     if (const QJsonValue v = f_json["other_name"]; v.isString())
         f_data.m_other_name = v.toString();
 
-    if (const QJsonValue v = f_json["self_x_offset"]; v.isDouble())
-        f_data.m_self_x_offset = v.toInt();
+    if (const QJsonValue v = f_json["self_offset"]; v.isObject()) {
+        OffsetData l_offset{0, 0};
+        QJsonObject l_json = v.toObject();
+        if (OffsetData::fromJson(l_json, l_offset)) {
+            f_data.m_self_offset = l_offset;
+        }
+    }
 
-    if (const QJsonValue v = f_json["self_y_offset"]; v.isDouble())
-        f_data.m_self_y_offset = v.toInt();
-
-    if (const QJsonValue v = f_json["other_x_offset"]; v.isDouble())
-        f_data.m_other_x_offset = v.toInt();
-
-    if (const QJsonValue v = f_json["other_y_offset"]; v.isDouble())
-        f_data.m_other_y_offset = v.toInt();
+    if (const QJsonValue v = f_json["other_offset"]; v.isObject()) {
+        OffsetData l_offset{0, 0};
+        QJsonObject l_json = v.toObject();
+        if (OffsetData::fromJson(l_json, l_offset)) {
+            f_data.m_other_offset = l_offset;
+        }
+    }
 
     if (const QJsonValue v = f_json["other_flip"]; v.isBool())
         f_data.m_other_flip = v.toBool();
@@ -190,10 +194,8 @@ QJsonObject ms2::OldMSFlatData::toJson() const
     json["other_charid"] = m_other_charid;
     json["other_name"] = m_other_name;
     json["other_emote"] = m_other_emote;
-    json["self_x_offset"] = m_self_x_offset;
-    json["self_y_offset"] = m_self_y_offset;
-    json["other_x_offset"] = m_other_x_offset;
-    json["other_y_offset"] = m_other_y_offset;
+    json["self_offset"] = m_self_offset.toJson();
+    json["other_offset"] = m_other_offset.toJson();
     json["other_flip"] = m_other_flip;
     json["immediate"] = m_immediate;
     json["sfx_looping"] = m_sfx_looping;
@@ -254,6 +256,31 @@ QJsonObject ms2::FrameData::toJson() const
     if (!m_value.isEmpty()) {
         json["value"] = m_value;
     }
+
+    return json;
+}
+
+bool ms2::OffsetData::fromJson(const QJsonObject &f_json, OffsetData &f_data)
+{
+    if (const QJsonValue v = f_json["x"]; v.isDouble())
+        f_data.x = std::max(-100, std::min(v.toInt(), 100));
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["y"]; v.isDouble())
+        f_data.y = std::max(-100, std::min(v.toInt(), 100));
+    else
+        return false;
+
+    return true;
+}
+
+QJsonObject ms2::OffsetData::toJson() const
+{
+    QJsonObject json;
+
+    json["x"] = x;
+    json["y"] = y;
 
     return json;
 }

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -149,8 +149,13 @@ bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_da
     if (const QJsonValue v = f_json["additive"]; v.isBool())
         f_data.m_additive = v.toBool();
 
-    if (const QJsonValue v = f_json["effect"]; v.isString())
-        f_data.m_effect = v.toString();
+    if (const QJsonValue v = f_json["effect"]; v.isObject()) {
+        EffectData l_effect{};
+        QJsonObject l_json = v.toObject();
+        if (EffectData::fromJson(l_json, l_effect)) {
+            f_data.m_effect = l_effect;
+        }
+    }
 
     if (const QJsonValue v = f_json["blips"]; v.isString())
         f_data.m_blips = v.toString();
@@ -208,7 +213,7 @@ QJsonObject ms2::OldMSFlatData::toJson() const
     }
 
     json["additive"] = m_additive;
-    json["effect"] = m_effect;
+    json["effect"] = m_effect.toJson();
     json["blips"] = m_blips;
     json["slide"] = m_slide;
 
@@ -319,6 +324,33 @@ QJsonObject ms2::OtherData::toJson() const
     json["offset"] = m_offset.toJson();
     json["flip"] = m_flip;
     json["under"] = m_under;
+
+    return json;
+}
+
+bool ms2::EffectData::fromJson(const QJsonObject &f_json, EffectData &f_data)
+{
+    if (const QJsonValue v = f_json["name"]; v.isString())
+        f_data.m_name = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["sound"]; v.isString())
+        f_data.m_sound = v.toString();
+
+    if (const QJsonValue v = f_json["folder"]; v.isString())
+        f_data.m_folder = v.toString();
+
+    return true;
+}
+
+QJsonObject ms2::EffectData::toJson() const
+{
+    QJsonObject json;
+
+    json["name"] = m_name;
+    json["sound"] = m_sound;
+    json["folder"] = m_folder;
 
     return json;
 }

--- a/src/packet/data/msdata.cpp
+++ b/src/packet/data/msdata.cpp
@@ -89,30 +89,21 @@ bool ms2::OldMSFlatData::fromJson(const QJsonObject &f_json, OldMSFlatData &f_da
     if (const QJsonValue v = f_json["showname"]; v.isString())
         f_data.m_showname = v.toString();
 
-    if (const QJsonValue v = f_json["other_charid"]; v.isDouble())
-        f_data.m_other_charid = v.toInt();
-
-    if (const QJsonValue v = f_json["other_name"]; v.isString())
-        f_data.m_other_name = v.toString();
-
-    if (const QJsonValue v = f_json["self_offset"]; v.isObject()) {
-        OffsetData l_offset{0, 0};
+    if (const QJsonValue v = f_json["other"]; v.isObject()) {
+        OtherData l_other;
         QJsonObject l_json = v.toObject();
-        if (OffsetData::fromJson(l_json, l_offset)) {
-            f_data.m_self_offset = l_offset;
+        if (OtherData::fromJson(l_json, l_other)) {
+            f_data.m_other = l_other;
         }
     }
 
-    if (const QJsonValue v = f_json["other_offset"]; v.isObject()) {
+    if (const QJsonValue v = f_json["offset"]; v.isObject()) {
         OffsetData l_offset{0, 0};
         QJsonObject l_json = v.toObject();
         if (OffsetData::fromJson(l_json, l_offset)) {
-            f_data.m_other_offset = l_offset;
+            f_data.m_offset = l_offset;
         }
     }
-
-    if (const QJsonValue v = f_json["other_flip"]; v.isBool())
-        f_data.m_other_flip = v.toBool();
 
     if (const QJsonValue v = f_json["immediate"]; v.isBool())
         f_data.m_immediate = v.toBool();
@@ -191,12 +182,8 @@ QJsonObject ms2::OldMSFlatData::toJson() const
     json["realisation"] = m_realisation;
     json["text_color"] = m_text_colour;
     json["showname"] = m_showname;
-    json["other_charid"] = m_other_charid;
-    json["other_name"] = m_other_name;
-    json["other_emote"] = m_other_emote;
-    json["self_offset"] = m_self_offset.toJson();
-    json["other_offset"] = m_other_offset.toJson();
-    json["other_flip"] = m_other_flip;
+    json["other"] = m_other.toJson();
+    json["offset"] = m_offset.toJson();
     json["immediate"] = m_immediate;
     json["sfx_looping"] = m_sfx_looping;
     json["screenshake"] = m_screenshake;
@@ -281,6 +268,57 @@ QJsonObject ms2::OffsetData::toJson() const
 
     json["x"] = x;
     json["y"] = y;
+
+    return json;
+}
+
+bool ms2::OtherData::fromJson(const QJsonObject &f_json, OtherData &f_data)
+{
+    if (const QJsonValue v = f_json["charid"]; v.isDouble())
+        f_data.m_charid = v.toInt();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["name"]; v.isString())
+        f_data.m_name = v.toString();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["offset"]; v.isObject()) {
+        OffsetData l_offset{0, 0};
+        QJsonObject l_json = v.toObject();
+        if (OffsetData::fromJson(l_json, l_offset)) {
+            f_data.m_offset = l_offset;
+        }
+        else
+            return false;
+    }
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["flip"]; v.isBool())
+        f_data.m_flip = v.toBool();
+    else
+        return false;
+
+    if (const QJsonValue v = f_json["under"]; v.isBool())
+        f_data.m_under = v.toBool();
+    else
+        return false;
+
+    return true;
+}
+
+QJsonObject ms2::OtherData::toJson() const
+{
+    QJsonObject json;
+
+    json["charid"] = m_charid;
+    json["name"] = m_name;
+    json["emote"] = m_emote;
+    json["offset"] = m_offset.toJson();
+    json["flip"] = m_flip;
+    json["under"] = m_under;
 
     return json;
 }

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -80,6 +80,7 @@ struct OldMSFlatData
     bool m_additive;
     QString m_effect;
     QString m_blips;
+    bool m_slide;
 
     /// Returns true if the minimal error-checking it does reported no issues when reading from JSON.
     static bool fromJson(const QJsonObject &f_json, OldMSFlatData &f_data);

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -16,11 +16,11 @@ enum class DeskMod
 
 enum class EmoteMod
 {
-    NoPre = 0,
+    Idle = 0,
     Pre,
     PreAndObject,
-    NoPreZoom,
-    NoPreObjZoom,
+    Zoom,
+    PreZoom,
 };
 
 enum class ObjectionMod

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -38,8 +38,15 @@ struct FrameData
     qint32 m_frame;
     QString m_value;
 
-    /// Returns true if the minimal error-checking it does reported no issues when reading from JSON.
     static bool fromJson(const QJsonObject &f_json, FrameData &f_data);
+    QJsonObject toJson() const;
+};
+
+struct OffsetData {
+    qint32 x;
+    qint32 y;
+
+    static bool fromJson(const QJsonObject &f_json, OffsetData &f_data);
     QJsonObject toJson() const;
 };
 
@@ -67,10 +74,8 @@ struct OldMSFlatData
     qint32 m_other_charid;
     QString m_other_name;
     QString m_other_emote;
-    qint32 m_self_x_offset;
-    qint32 m_self_y_offset;
-    qint32 m_other_x_offset;
-    qint32 m_other_y_offset;
+    OffsetData m_self_offset;
+    OffsetData m_other_offset;
     bool m_other_flip;
     bool m_immediate;
     bool m_sfx_looping;

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -31,6 +31,17 @@ enum class ObjectionMod
     Custom,
 };
 
+struct FrameData
+{
+    QString m_emote;
+    qint32 m_frame;
+    QString m_value;
+
+    /// Returns true if the minimal error-checking it does reported no issues when reading from JSON.
+    static bool fromJson(const QJsonObject &f_json, FrameData &f_data);
+    QJsonObject toJson() const;
+};
+
 /// This is a super-basic representation of the old MS packet in the flattest JSON form possible.
 /// Intentionally minimal types, almost no error checking.
 struct OldMSFlatData
@@ -63,9 +74,9 @@ struct OldMSFlatData
     bool m_immediate;
     bool m_sfx_looping;
     bool m_screenshake;
-    QList<qint32> m_frames_shake;
-    QList<qint32> m_frames_realisation;
-    QList<qint32> m_frames_sfx;
+    QList<FrameData> m_frames_shake;
+    QList<FrameData> m_frames_realisation;
+    QList<FrameData> m_frames_sfx;
     bool m_additive;
     QString m_effect;
     QString m_blips;

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -50,6 +50,19 @@ struct OffsetData {
     QJsonObject toJson() const;
 };
 
+struct OtherData
+{
+    qint32 m_charid;
+    QString m_name;
+    QString m_emote;
+    OffsetData m_offset;
+    bool m_flip;
+    bool m_under;
+
+    static bool fromJson(const QJsonObject &f_json, OtherData &f_data);
+    QJsonObject toJson() const;
+};
+
 /// This is a super-basic representation of the old MS packet in the flattest JSON form possible.
 /// Intentionally minimal types, almost no error checking.
 struct OldMSFlatData
@@ -71,15 +84,11 @@ struct OldMSFlatData
     bool m_realisation;
     qint32 m_text_colour;
     QString m_showname;
-    qint32 m_other_charid;
-    QString m_other_name;
-    QString m_other_emote;
-    OffsetData m_self_offset;
-    OffsetData m_other_offset;
-    bool m_other_flip;
+    OffsetData m_offset;
     bool m_immediate;
     bool m_sfx_looping;
     bool m_screenshake;
+    OtherData m_other;
     QList<FrameData> m_frames_shake;
     QList<FrameData> m_frames_realisation;
     QList<FrameData> m_frames_sfx;

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QList>
+
+namespace ms2 {
+enum class DeskMod
+{
+    Shown = 1,
+    HiddenDuringPreThenShown,
+    ShowDuringPreThenHidden,
+    HiddenCentreThenShown,
+    ShownThenHiddenCentre,
+};
+
+enum class EmoteMod
+{
+    NoPre = 0,
+    Pre,
+    PreAndObject,
+    NoPreZoom,
+    NoPreObjZoom,
+};
+
+enum class ObjectionMod
+{
+    None = 0,
+    HoldIt,
+    Objection,
+    TakeThat,
+    Custom,
+};
+
+/// This is a super-basic representation of the old MS packet in the flattest JSON form possible.
+/// Intentionally minimal types, almost no error checking.
+struct OldMSFlatData
+{
+    DeskMod m_desk_mod;
+    QString m_preanim;
+    QString m_char_name;
+    QString m_emote;
+    QString m_message_text;
+    QString m_side;
+    QString m_sfx_name;
+    EmoteMod m_emote_mod;
+    qint32 m_char_id;
+    qint32 m_sfx_delay;
+    ObjectionMod m_objection_mod;
+    QString m_objection_custom;
+    qint32 m_evidence;
+    bool m_flip;
+    bool m_realisation;
+    qint32 m_text_colour;
+    QString m_showname;
+    qint32 m_other_charid;
+    QString m_other_name;
+    QString m_other_emote;
+    qint32 m_self_x_offset;
+    qint32 m_self_y_offset;
+    qint32 m_other_x_offset;
+    qint32 m_other_y_offset;
+    bool m_other_flip;
+    bool m_immediate;
+    bool m_sfx_looping;
+    bool m_screenshake;
+    QList<qint32> m_frames_shake;
+    QList<qint32> m_frames_realisation;
+    QList<qint32> m_frames_sfx;
+    bool m_additive;
+    QString m_effect;
+    QString m_blips;
+
+    /// Returns true if the minimal error-checking it does reported no issues when reading from JSON.
+    static bool fromJson(const QJsonObject &f_json, OldMSFlatData &f_data);
+    QJsonObject toJson() const;
+};
+}

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -63,6 +63,16 @@ struct OtherData
     QJsonObject toJson() const;
 };
 
+struct EffectData
+{
+    QString m_name;
+    QString m_sound;
+    QString m_folder;
+
+    static bool fromJson(const QJsonObject &f_json, EffectData &f_data);
+    QJsonObject toJson() const;
+};
+
 /// This is a super-basic representation of the old MS packet in the flattest JSON form possible.
 /// Intentionally minimal types, almost no error checking.
 struct OldMSFlatData
@@ -93,7 +103,7 @@ struct OldMSFlatData
     QList<FrameData> m_frames_realisation;
     QList<FrameData> m_frames_sfx;
     bool m_additive;
-    QString m_effect;
+    EffectData m_effect;
     QString m_blips;
     bool m_slide;
 

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -6,7 +6,8 @@
 namespace ms2 {
 enum class DeskMod
 {
-    Shown = 1,
+    Hidden = 0,
+    Shown,
     HiddenDuringPreThenShown,
     ShowDuringPreThenHidden,
     HiddenCentreThenShown,

--- a/src/packet/data/msdata.h
+++ b/src/packet/data/msdata.h
@@ -42,7 +42,8 @@ struct FrameData
     QJsonObject toJson() const;
 };
 
-struct OffsetData {
+struct OffsetData
+{
     qint32 x;
     qint32 y;
 

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -208,7 +208,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     }
     {
         // other char id
-        client.m_pairing_with = message.m_other_charid;
+        client.m_pairing_with = message.m_other.m_charid;
         QString l_front_back = "";
         int l_other_charid = client.m_pairing_with;
         bool l_pairing = false;
@@ -230,15 +230,15 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
             l_other_charid = -1;
             l_front_back = "";
         }
-        message.m_other_name = l_other_name;
-        message.m_other_charid = l_other_charid;
-        message.m_other_emote = l_other_emote;
-        message.m_other_flip = l_other_flip;
-        message.m_other_offset = l_other_offset;
+        message.m_other.m_name = l_other_name;
+        message.m_other.m_charid = l_other_charid;
+        message.m_other.m_emote = l_other_emote;
+        message.m_other.m_flip = l_other_flip;
+        message.m_other.m_offset = l_other_offset;
     }
     {
         // self offset
-        client.m_offset = message.m_self_offset;
+        client.m_offset = message.m_offset;
     }
     {
         // immediate text processing

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -214,7 +214,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         bool l_pairing = false;
         QString l_other_name = "0";
         QString l_other_emote = "0";
-        QPair<qint32, qint32> l_other_offset{0, 0};
+        ms2::OffsetData l_other_offset{0, 0};
         bool l_other_flip = false;
         for (int l_client_id : area->joinedIDs()) {
             AOClient *l_client = client.getServer()->getClientByID(l_client_id);
@@ -234,12 +234,11 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         message.m_other_charid = l_other_charid;
         message.m_other_emote = l_other_emote;
         message.m_other_flip = l_other_flip;
-        message.m_other_x_offset = l_other_offset.first;
-        message.m_other_y_offset = l_other_offset.second;
+        message.m_other_offset = l_other_offset;
     }
     {
         // self offset
-        client.m_offset = {message.m_self_x_offset, message.m_self_y_offset};
+        client.m_offset = message.m_self_offset;
     }
     {
         // immediate text processing

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -1,9 +1,11 @@
 #include "packet/packet_ms.h"
 #include "config_manager.h"
+#include "packet/data/msdata.h"
 #include "packet/packet_factory.h"
 #include "server.h"
 
 #include <QDebug>
+#include <QJsonDocument>
 #include <QRegularExpression>
 
 PacketMS::PacketMS(QStringList &contents) :
@@ -15,7 +17,7 @@ PacketInfo PacketMS::getPacketInfo() const
 {
     PacketInfo info{
         .acl_permission = ACLRole::Permission::NONE,
-        .min_args = 15,
+        .min_args = 1,
         .header = "MS"};
     return info;
 }
@@ -59,7 +61,6 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     // 2.6+ extensions raise this to 19, and 2.8 further raises this to 26.
 
     AOPacket *l_invalid = PacketFactory::createPacket("INVALID", {});
-    QStringList l_args;
     if (client.isSpectator() || client.character().isEmpty() || !client.m_joined)
         // Spectators cannot use IC
         return l_invalid;
@@ -68,197 +69,128 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         // Non-invited players cannot speak in spectatable areas
         return l_invalid;
 
-    QList<QVariant> l_incoming_args;
-    for (const QString &l_arg : m_content) {
-        l_incoming_args.append(QVariant(l_arg));
-    }
-
-    // desk modifier
-    QStringList allowed_desk_mods;
-    allowed_desk_mods << "chat"
-                      << "0"
-                      << "1"
-                      << "2"
-                      << "3"
-                      << "4"
-                      << "5";
-    QString l_incoming_deskmod = l_incoming_args[0].toString();
-    if (allowed_desk_mods.contains(l_incoming_deskmod)) {
-        // **WARNING : THIS IS A HACK!**
-        // A proper solution would be to deprecate chat as an argument on the clientside
-        // instead of overwriting correct netcode behaviour on the serverside.
-        if (l_incoming_deskmod == "chat") {
-            l_args.append("1");
-        }
-        else {
-            l_args.append(l_incoming_args[0].toString());
-        }
-    }
-    else
-        return l_invalid;
-
-    // preanim
-    l_args.append(l_incoming_args[1].toString());
-
-    // char name
-    if (client.character().toLower() != l_incoming_args[2].toString().toLower()) {
-        // Selected char is different from supplied folder name
-        // This means the user is INI-swapped
-        if (!area->iniswapAllowed()) {
-            QStringList l_character_split = l_incoming_args[2].toString().split("/");
-            if (!client.getServer()->getCharacters().contains(l_character_split.at(0), Qt::CaseInsensitive) || l_character_split.contains(".."))
-                return l_invalid;
-        }
-        qDebug() << "INI swap detected from " << client.getIpid();
-    }
-    client.m_current_iniswap = l_incoming_args[2].toString();
-    l_args.append(l_incoming_args[2].toString());
-
-    // emote
-    client.m_emote = l_incoming_args[3].toString();
-    if (client.m_first_person)
-        client.m_emote = "";
-    l_args.append(client.m_emote);
-
-    // message text
-    if (l_incoming_args[4].toString().size() > ConfigManager::maxCharacters())
-        return l_invalid;
-
-    // Doublepost prevention. Has to ignore blankposts and testimony commands.
-    QString l_incoming_msg = client.dezalgo(l_incoming_args[4].toString().trimmed());
-    QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(l_incoming_msg));
-    bool msg_is_testimony_cmd = (match.hasMatch() || l_incoming_msg == ">" || l_incoming_msg == "<");
-    if (!client.m_last_message.isEmpty()           // If the last message you sent isn't empty,
-        && l_incoming_msg == client.m_last_message // and it matches the one you're sending,
-        && !msg_is_testimony_cmd)                  // and it's not a testimony command,
-        return l_invalid;                          // get it the hell outta here!
-
-    if (l_incoming_msg == "" && area->blankpostingAllowed() == false) {
-        client.sendServerMessage("Blankposting has been forbidden in this area.");
+    const auto l_incoming = QJsonDocument::fromJson(m_content.at(0).toUtf8());
+    ms2::OldMSFlatData message;
+    if (ms2::OldMSFlatData::fromJson(l_incoming.object(), message)) {
         return l_invalid;
     }
 
-    if (!ConfigManager::filterList().isEmpty()) {
-        foreach (const QString &regex, ConfigManager::filterList()) {
-            QRegularExpression re(regex, QRegularExpression::CaseInsensitiveOption);
-            l_incoming_msg.replace(re, "❌");
-        }
-    }
-
-    if (client.m_is_gimped) {
-        QString l_gimp_message = ConfigManager::gimpList().at((client.genRand(1, ConfigManager::gimpList().size() - 1)));
-        l_incoming_msg = l_gimp_message;
-    }
-
-    if (client.m_is_shaken) {
-        QStringList l_parts = l_incoming_msg.split(" ");
-
-        std::random_device rng;
-        std::mt19937 urng(rng());
-        std::shuffle(l_parts.begin(), l_parts.end(), urng);
-
-        l_incoming_msg = l_parts.join(" ");
-    }
-
-    if (client.m_is_disemvoweled) {
-        QString l_disemvoweled_message = l_incoming_msg.remove(QRegularExpression("[AEIOUaeiou]"));
-        l_incoming_msg = l_disemvoweled_message;
-    }
-
-    client.m_last_message = l_incoming_msg;
-    l_args.append(l_incoming_msg);
-
-    // side
-    // this is validated clientside so w/e
-    QString side = area->side();
-    if (side.isEmpty()) {
-        side = l_incoming_args[5].toString();
-    }
-    l_args.append(side);
-
-    if (client.m_pos != l_incoming_args[5].toString()) {
-        client.m_pos = l_incoming_args[5].toString();
-        client.m_pos.replace("../", "").replace("..\\", "");
-        client.updateEvidenceList(client.getServer()->getAreaById(client.areaId()));
-    }
-
-    // sfx name
-    l_args.append(l_incoming_args[6].toString());
-
-    // emote modifier
-    // Now, gather round, y'all. Here is a story that is truly a microcosm of the AO dev experience.
-    // If this value is a 4, it will crash the client. Why? Who knows, but it does.
-    // Now here is the kicker: in certain versions, the client would incorrectly send a 4 here
-    // For a long time, by configuring the client to do a zoom with a preanim, it would send 4
-    // This would crash everyone else's client, and the feature had to be disabled
-    // But, for some reason, nobody traced the cause of this issue for many many years.
-    // The serverside fix is needed to ensure invalid values are not sent, because the client sucks
-    int emote_mod = l_incoming_args[7].toInt();
-
-    if (emote_mod == 4)
-        emote_mod = 6;
-    if (emote_mod != 0 && emote_mod != 1 && emote_mod != 2 && emote_mod != 5 && emote_mod != 6)
-        return l_invalid;
-    l_args.append(QString::number(emote_mod));
-
-    // char id
-    if (l_incoming_args[8].toInt() != client.m_char_id)
-        return l_invalid;
-    l_args.append(l_incoming_args[8].toString());
-
-    // sfx delay
-    l_args.append(l_incoming_args[9].toString());
-
-    // objection modifier
-    if (area->isShoutAllowed()) {
-        if (l_incoming_args[10].toString().contains("4")) {
-            // custom shout includes text metadata
-            l_args.append(l_incoming_args[10].toString());
-        }
-        else {
-            int l_obj_mod = l_incoming_args[10].toInt();
-            if ((l_obj_mod < 0) || (l_obj_mod > 4)) {
-                return l_invalid;
+    {
+        // char name
+        if (client.character().toLower() != message.m_char_name.toLower()) {
+            // Selected char is different from supplied folder name
+            // This means the user is INI-swapped
+            if (!area->iniswapAllowed()) {
+                QStringList l_character_split = message.m_char_name.split("/");
+                if (!client.getServer()->getCharacters().contains(l_character_split.at(0), Qt::CaseInsensitive) || l_character_split.contains(".."))
+                    return l_invalid;
             }
-            l_args.append(QString::number(l_obj_mod));
+            qDebug() << "INI swap detected from " << client.getIpid();
+        }
+        client.m_current_iniswap = message.m_char_name;
+    }
+    {
+        // emote
+        client.m_emote = message.m_emote;
+        if (client.m_first_person)
+            client.m_emote = "";
+        message.m_emote = client.m_emote;
+    }
+    {
+        // message text
+        if (message.m_message_text.size() > ConfigManager::maxCharacters())
+            return l_invalid;
+
+        // Doublepost prevention. Has to ignore blankposts and testimony commands.
+        QString l_incoming_msg = client.dezalgo(message.m_message_text.trimmed());
+        QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(l_incoming_msg));
+        bool msg_is_testimony_cmd = (match.hasMatch() || l_incoming_msg == ">" || l_incoming_msg == "<");
+        if (!client.m_last_message.isEmpty()           // If the last message you sent isn't empty,
+            && l_incoming_msg == client.m_last_message // and it matches the one you're sending,
+            && !msg_is_testimony_cmd)                  // and it's not a testimony command,
+            return l_invalid;                          // get it the hell outta here!
+
+        if (l_incoming_msg == "" && area->blankpostingAllowed() == false) {
+            client.sendServerMessage("Blankposting has been forbidden in this area.");
+            return l_invalid;
+        }
+
+        if (!ConfigManager::filterList().isEmpty()) {
+            foreach (const QString &regex, ConfigManager::filterList()) {
+                QRegularExpression re(regex, QRegularExpression::CaseInsensitiveOption);
+                l_incoming_msg.replace(re, "❌");
+            }
+        }
+
+        if (client.m_is_gimped) {
+            QString l_gimp_message = ConfigManager::gimpList().at((client.genRand(1, ConfigManager::gimpList().size() - 1)));
+            l_incoming_msg = l_gimp_message;
+        }
+
+        if (client.m_is_shaken) {
+            QStringList l_parts = l_incoming_msg.split(" ");
+
+            std::random_device rng;
+            std::mt19937 urng(rng());
+            std::shuffle(l_parts.begin(), l_parts.end(), urng);
+
+            l_incoming_msg = l_parts.join(" ");
+        }
+
+        if (client.m_is_disemvoweled) {
+            QString l_disemvoweled_message = l_incoming_msg.remove(QRegularExpression("[AEIOUaeiou]"));
+            l_incoming_msg = l_disemvoweled_message;
+        }
+
+        client.m_last_message = l_incoming_msg;
+        message.m_message_text = l_incoming_msg;
+    }
+    {
+        // side
+        // this is validated clientside so w/e
+        QString side = area->side();
+        if (side.isEmpty()) {
+            side = message.m_side;
+        }
+        message.m_side = side;
+
+        if (client.m_pos != message.m_side) {
+            client.m_pos = message.m_side;
+            client.m_pos.replace("../", "").replace("..\\", "");
+            client.updateEvidenceList(client.getServer()->getAreaById(client.areaId()));
         }
     }
-    else {
-        if (l_incoming_args[10].toString() != "0") {
-            client.sendServerMessage("Shouts have been disabled in this area.");
-        }
-        l_args.append("0");
+    {
+        // char id
+        if (message.m_char_id != client.m_char_id)
+            return l_invalid;
     }
-
-    // evidence
-    int evi_idx = l_incoming_args[11].toInt();
-    if (evi_idx > area->evidence().length())
-        return l_invalid;
-    l_args.append(QString::number(evi_idx));
-
-    // flipping
-    int l_flip = l_incoming_args[12].toInt();
-    if (l_flip != 0 && l_flip != 1)
-        return l_invalid;
-    client.m_flipping = QString::number(l_flip);
-    l_args.append(client.m_flipping);
-
-    // realization
-    int realization = l_incoming_args[13].toInt();
-    if (realization != 0 && realization != 1)
-        return l_invalid;
-    l_args.append(QString::number(realization));
-
-    // text color
-    int text_color = l_incoming_args[14].toInt();
-    if (text_color < 0 || text_color > 11)
-        return l_invalid;
-    l_args.append(QString::number(text_color));
-
-    // 2.6 packet extensions
-    if (l_incoming_args.length() >= 19) {
+    {
+        // objection modifier
+        if (!area->isShoutAllowed()) {
+            if (message.m_objection_mod != ms2::ObjectionMod::None) {
+                client.sendServerMessage("Shouts have been disabled in this area.");
+                message.m_objection_mod = ms2::ObjectionMod::None;
+            }
+        }
+    }
+    {
+        // evidence
+        if (message.m_evidence > area->evidence().length())
+            return l_invalid;
+    }
+    {
+        // flipping
+        client.m_flipping = message.m_flip;
+    }
+    {
+        // text color
+        if (message.m_text_colour < 0 || message.m_text_colour > 11)
+            return l_invalid;
+    }
+    {
         // showname
-        QString l_incoming_showname = client.dezalgo(l_incoming_args[15].toString().trimmed());
+        QString l_incoming_showname = client.dezalgo(message.m_showname.trimmed());
         if (!(l_incoming_showname == client.character() || l_incoming_showname.isEmpty()) && !area->shownameAllowed()) {
             client.sendServerMessage("Shownames are not allowed in this area!");
             return l_invalid;
@@ -269,25 +201,21 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         }
 
         // if the raw input is not empty but the trimmed input is, use a single space
-        if (l_incoming_showname.isEmpty() && !l_incoming_args[15].toString().isEmpty())
+        if (l_incoming_showname.isEmpty() && !message.m_showname.isEmpty())
             l_incoming_showname = " ";
-        l_args.append(l_incoming_showname);
+        message.m_showname = l_incoming_showname;
         client.setCharacterName(l_incoming_showname);
-
+    }
+    {
         // other char id
-        // things get a bit hairy here
-        // don't ask me how this works, because i don't know either
-        QStringList l_pair_data = l_incoming_args[16].toString().split("^");
-        client.m_pairing_with = l_pair_data[0].toInt();
+        client.m_pairing_with = message.m_other_charid;
         QString l_front_back = "";
-        if (l_pair_data.length() > 1)
-            l_front_back = "^" + l_pair_data[1];
         int l_other_charid = client.m_pairing_with;
         bool l_pairing = false;
         QString l_other_name = "0";
         QString l_other_emote = "0";
-        QString l_other_offset = "0";
-        QString l_other_flip = "0";
+        QPair<qint32, qint32> l_other_offset{0, 0};
+        bool l_other_flip = false;
         for (int l_client_id : area->joinedIDs()) {
             AOClient *l_client = client.getServer()->getClientByID(l_client_id);
             if (l_client->m_pairing_with == client.m_char_id && l_other_charid != client.m_char_id && l_client->m_char_id == client.m_pairing_with && l_client->m_pos == client.m_pos) {
@@ -302,90 +230,37 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
             l_other_charid = -1;
             l_front_back = "";
         }
-        l_args.append(QString::number(l_other_charid) + l_front_back);
-        l_args.append(l_other_name);
-        l_args.append(l_other_emote);
-
-        // self offset
-        client.m_offset = l_incoming_args[17].toString();
-        // versions 2.6-2.8 cannot validate y-offset so we send them just the x-offset
-        if ((client.m_version.release == 2) && (client.m_version.major == 6 || client.m_version.major == 7 || client.m_version.major == 8)) {
-            QString l_x_offset = client.m_offset.split("&")[0];
-            l_args.append(l_x_offset);
-            QString l_other_x_offset = l_other_offset.split("&")[0];
-            l_args.append(l_other_x_offset);
-        }
-        else {
-            l_args.append(client.m_offset);
-            l_args.append(l_other_offset);
-        }
-        l_args.append(l_other_flip);
-
-        // immediate text processing
-        int l_immediate = l_incoming_args[18].toInt();
-        if (area->forceImmediate()) {
-            if (l_args[7] == "1" || l_args[7] == "2") {
-                l_args[7] = "0";
-                l_immediate = 1;
-            }
-            else if (l_args[7] == "6") {
-                l_args[7] = "5";
-                l_immediate = 1;
-            }
-        }
-        if (l_immediate != 1 && l_immediate != 0)
-            return l_invalid;
-        l_args.append(QString::number(l_immediate));
+        message.m_other_name = l_other_name;
+        message.m_other_charid = l_other_charid;
+        message.m_other_emote = l_other_emote;
+        message.m_other_flip = l_other_flip;
+        message.m_other_x_offset = l_other_offset.first;
+        message.m_other_y_offset = l_other_offset.second;
     }
-
-    // 2.8 packet extensions
-    if (l_incoming_args.length() >= 26) {
-        // sfx looping
-        int l_sfx_loop = l_incoming_args[19].toInt();
-        if (l_sfx_loop != 0 && l_sfx_loop != 1)
-            return l_invalid;
-        l_args.append(QString::number(l_sfx_loop));
-
-        // screenshake
-        int l_screenshake = l_incoming_args[20].toInt();
-        if (l_screenshake != 0 && l_screenshake != 1)
-            return l_invalid;
-        l_args.append(QString::number(l_screenshake));
-
-        // frames shake
-        l_args.append(l_incoming_args[21].toString());
-
-        // frames realization
-        l_args.append(l_incoming_args[22].toString());
-
-        // frames sfx
-        l_args.append(l_incoming_args[23].toString());
-
+    {
+        // self offset
+        client.m_offset = {message.m_self_x_offset, message.m_self_y_offset};
+    }
+    {
+        // immediate text processing
+        if (area->forceImmediate()) {
+            message.m_immediate = true;
+            if (message.m_emote_mod == ms2::EmoteMod::NoPreObjZoom) {
+                message.m_emote_mod = ms2::EmoteMod::NoPreZoom;
+            }
+        }
+    }
+    {
         // additive
-        int l_additive = l_incoming_args[24].toInt();
-        if (l_additive != 0 && l_additive != 1)
-            return l_invalid;
-        else if (area->lastICMessage().isEmpty()) {
-            l_additive = 0;
+        if (area->lastICMessage().isEmpty()) {
+            message.m_additive = false;
         }
         else if (!(client.m_char_id == area->lastICMessage()[8].toInt())) {
-            l_additive = 0;
+            message.m_additive = false;
         }
-        else if (l_additive == 1) {
-            l_args[4].insert(0, " ");
+        else if (message.m_additive == true) {
+            message.m_message_text.insert(0, " ");
         }
-        l_args.append(QString::number(l_additive));
-
-        // effect
-        l_args.append(l_incoming_args[25].toString());
-    }
-    if (l_incoming_args.size() >= 27) {
-        // blips
-        l_args.append(l_incoming_args[26].toString());
-    }
-    if (l_incoming_args.size() >= 28) {
-        // slide toggle
-        l_args.append(l_incoming_args[27].toString());
     }
 
     // Testimony playback
@@ -396,23 +271,23 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     if (area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING || area->testimonyRecording() == AreaData::TestimonyRecording::ADD) {
         // -1 indicates title
         if (area->statement() == -1) {
-            l_args[4] = "~~-- " + l_args[4] + " --";
-            l_args[14] = "3";
+            message.m_message_text = "~~-- " + message.m_message_text + " --";
+            message.m_text_colour = 3;
             client.getServer()->broadcast(PacketFactory::createPacket("RT", {"testimony1", "0"}), client.areaId());
         }
-        client.addStatement(l_args);
+        client.addStatement(message);
     }
     else if (area->testimonyRecording() == AreaData::TestimonyRecording::UPDATE) {
-        l_args = client.updateStatement(l_args);
+        message = client.updateStatement(message);
     }
     else if (area->testimonyRecording() == AreaData::TestimonyRecording::PLAYBACK) {
         AreaData::TestimonyProgress l_progress;
 
-        if (l_args[4] == ">") {
+        if (message.m_message_text == ">") {
             auto l_statement = area->jumpToStatement(area->statement() + 1);
-            l_args = l_statement.first;
+            message = l_statement.first;
             l_progress = l_statement.second;
-            client.m_pos = l_args[5];
+            client.m_pos = message.m_side;
 
             client.sendServerMessageArea(client_name + " moved to the next statement.");
 
@@ -420,11 +295,11 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
                 client.sendServerMessageArea("Last statement reached. Looping to first statement.");
             }
         }
-        if (l_args[4] == "<") {
+        if (message.m_message_text == "<") {
             auto l_statement = area->jumpToStatement(area->statement() - 1);
-            l_args = l_statement.first;
+            message = l_statement.first;
             l_progress = l_statement.second;
-            client.m_pos = l_args[5];
+            client.m_pos = message.m_side;
 
             client.sendServerMessageArea(client_name + " moved to the previous statement.");
 
@@ -432,20 +307,20 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
                 client.sendServerMessage("First statement reached.");
             }
         }
-        if (l_args[4] == "=") {
+        if (message.m_message_text == "=") {
             auto l_statement = area->jumpToStatement(area->statement());
-            l_args = l_statement.first;
+            message = l_statement.first;
             l_progress = l_statement.second;
-            client.m_pos = l_args[5];
+            client.m_pos = message.m_side;
 
             client.sendServerMessageArea(client_name + " repeated the current statement.");
         }
 
-        QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(l_args[4])); // Get rid of that pesky encoding, then do the fun part
+        QRegularExpressionMatch match = isTestimonyJumpCommand(client.decodeMessage(message.m_message_text)); // Get rid of that pesky encoding, then do the fun part
         if (match.hasMatch()) {
             int jump_idx = match.captured("int").toInt();
             auto l_statement = area->jumpToStatement(jump_idx);
-            l_args = l_statement.first;
+            message = l_statement.first;
             l_progress = l_statement.second;
 
             client.sendServerMessageArea(client_name + " jumped to statement number " + QString::number(jump_idx) + ".");
@@ -469,7 +344,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         }
     }
 
-    return PacketFactory::createPacket("MS", l_args);
+    return PacketFactory::createPacket("MS", {QJsonDocument{message.toJson()}.toJson()});
 }
 
 QRegularExpressionMatch PacketMS::isTestimonyJumpCommand(QString message) const

--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -212,13 +212,16 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
         QString l_front_back = "";
         int l_other_charid = client.m_pairing_with;
         bool l_pairing = false;
-        QString l_other_name = "0";
-        QString l_other_emote = "0";
+        QString l_other_name{};
+        QString l_other_emote{};
         ms2::OffsetData l_other_offset{0, 0};
         bool l_other_flip = false;
         for (int l_client_id : area->joinedIDs()) {
             AOClient *l_client = client.getServer()->getClientByID(l_client_id);
-            if (l_client->m_pairing_with == client.m_char_id && l_other_charid != client.m_char_id && l_client->m_char_id == client.m_pairing_with && l_client->m_pos == client.m_pos) {
+            if (l_client->m_pairing_with == client.m_char_id &&
+                l_other_charid != client.m_char_id &&
+                l_client->m_char_id == client.m_pairing_with &&
+                l_client->m_pos == client.m_pos) {
                 l_other_name = l_client->m_current_iniswap;
                 l_other_emote = l_client->m_emote;
                 l_other_offset = l_client->m_offset;

--- a/src/testimony_recorder.cpp
+++ b/src/testimony_recorder.cpp
@@ -21,9 +21,9 @@
 #include "config_manager.h"
 #include "server.h"
 
-void AOClient::addStatement(QStringList packet)
+void AOClient::addStatement(ms2::OldMSFlatData packet)
 {
-    if (checkTestimonySymbols(packet[4])) {
+    if (checkTestimonySymbols(packet.m_message_text)) {
         return;
     }
     AreaData *area = server->getAreaById(areaId());
@@ -32,9 +32,9 @@ void AOClient::addStatement(QStringList packet)
         if (area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING) {
             if (c_statement <= ConfigManager::maxStatements()) {
                 if (c_statement == -1)
-                    packet[14] = "3";
+                    packet.m_text_colour = 3;
                 else
-                    packet[14] = "1";
+                    packet.m_text_colour = 1;
                 area->recordStatement(packet);
                 return;
             }
@@ -43,7 +43,7 @@ void AOClient::addStatement(QStringList packet)
             }
         }
         else if (area->testimonyRecording() == AreaData::TestimonyRecording::ADD) {
-            packet[14] = "1";
+            packet.m_text_colour = 1;
             area->addStatement(c_statement + 1, packet);
             area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
         }
@@ -54,18 +54,18 @@ void AOClient::addStatement(QStringList packet)
     }
 }
 
-QStringList AOClient::updateStatement(QStringList packet)
+ms2::OldMSFlatData AOClient::updateStatement(ms2::OldMSFlatData packet)
 {
-    if (checkTestimonySymbols(packet[4])) {
+    if (checkTestimonySymbols(packet.m_message_text)) {
         return packet;
     }
     AreaData *area = server->getAreaById(areaId());
     int c_statement = area->statement();
     area->setTestimonyRecording(AreaData::TestimonyRecording::PLAYBACK);
-    if (c_statement <= 0 || area->testimony()[c_statement].empty())
+    if (c_statement <= 0)
         sendServerMessage("Unable to update an empty statement. Please use /addtestimony.");
     else {
-        packet[14] = "1";
+        packet.m_text_colour = 1;
         area->replaceStatement(c_statement, packet);
         sendServerMessage("Updated current statement.");
         return area->testimony()[c_statement];

--- a/tests/unittest_aopacket/tst_unittest_aopacket.cpp
+++ b/tests/unittest_aopacket/tst_unittest_aopacket.cpp
@@ -92,7 +92,7 @@ void Packet::createPacketSubclass_data()
                         << 2;
     QTest::newRow("MS") << "MS#"
                         << "MS"
-                        << 15;
+                        << 1;
     QTest::newRow("PE") << "PE#"
                         << "PE"
                         << 3;

--- a/tests/unittest_area/tst_unittest_area.cpp
+++ b/tests/unittest_area/tst_unittest_area.cpp
@@ -202,20 +202,26 @@ void Area::changeCharacter()
 
 void Area::testimony()
 {
-    QVector<QStringList> l_testimony = {
-        {"A"},
-        {"B"},
-        {"C"},
-        {"D"},
-        {"E"},
+    QVector<ms2::OldMSFlatData> l_testimony = {
+        ms2::OldMSFlatData{},
+        ms2::OldMSFlatData{},
+        ms2::OldMSFlatData{},
+        ms2::OldMSFlatData{},
+        ms2::OldMSFlatData{},
     };
+
+    l_testimony[0].m_message_text = "A";
+    l_testimony[1].m_message_text = "B";
+    l_testimony[2].m_message_text = "C";
+    l_testimony[3].m_message_text = "D";
+    l_testimony[4].m_message_text = "E";
 
     {
         // Add all statements, and check that they're added.
         for (const auto &l_statement : l_testimony) {
             m_area->recordStatement(l_statement);
 
-            QCOMPARE(l_statement, m_area->testimony().at(m_area->statement() - 1));
+            QCOMPARE(l_statement.m_message_text, m_area->testimony().at(m_area->statement() - 1).m_message_text);
         }
     }
     {
@@ -225,7 +231,7 @@ void Area::testimony()
         for (int i = 1; i < l_testimony.size() - 1; i++) {
             const auto &l_results = m_area->jumpToStatement(m_area->statement() + 1);
 
-            QCOMPARE(l_results.first, l_testimony.at(i + 1));
+            QCOMPARE(l_results.first.m_message_text, l_testimony.at(i + 1).m_message_text);
             QCOMPARE(l_results.second, AreaData::TestimonyProgress::OK);
         }
     }
@@ -233,14 +239,14 @@ void Area::testimony()
         // Next advancement loops the testimony.
         const auto &l_results = m_area->jumpToStatement(m_area->statement() + 1);
 
-        QCOMPARE(l_results.first, l_testimony.at(1));
+        QCOMPARE(l_results.first.m_message_text, l_testimony.at(1).m_message_text);
         QCOMPARE(l_results.second, AreaData::TestimonyProgress::LOOPED);
     }
     {
         // Going back makes the testimony stay at the first statement.
         const auto &l_results = m_area->jumpToStatement(m_area->statement() - 1);
 
-        QCOMPARE(l_results.first, l_testimony.at(1));
+        QCOMPARE(l_results.first.m_message_text, l_testimony.at(1).m_message_text);
         QCOMPARE(l_results.second, AreaData::TestimonyProgress::STAYED_AT_FIRST);
     }
 }


### PR DESCRIPTION
I offhandedly mentioned in The `[DATA EXPUNGED]` that if we wanna do something with the `MS` packet, probably the best way to go about it is to make at least its cursed insides a JSON, and  the best way to go about *that* is to create a MVP of sorts.

So, here it is.

I specifically aimed this to be the minimalest of viable products -- there is no real extra fancy decision making about AO's `MS` packet, it's literally just the flattest possible representation of it, except in JSON.

I'll write the client part of it later, but until then, I'll keep this a draft.

As to how to proceed from this point on, it'll largely depend on what we want. The Akashi part of the deal is going to be the easier pain to deal with. This MS data representation is preferably thrown out, however.

I could also imagine a separate library just for the MS packet (and perhaps other packets later) that both the client and Akashi pull in.