### PR TITLE
Fix jumping to statements in testimony causing testimony to play at the wrong position

### DIFF
--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -447,6 +447,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
             auto l_statement = area->jumpToStatement(jump_idx);
             l_args = l_statement.first;
             l_progress = l_statement.second;
+            client.m_pos = l_args[5];
 
             client.sendServerMessageArea(client_name + " jumped to statement number " + QString::number(jump_idx) + ".");
 


### PR DESCRIPTION
Band-aid fix for the worse of two issues. The testimony playback system needs a rework to not hijack client objects like this but in the meantime restoring the old behavior is better