### PR TITLE
Do not record blank posts as testimony

### DIFF
--- a/src/packet/packet_ms.cpp
+++ b/src/packet/packet_ms.cpp
@@ -437,7 +437,7 @@ AOPacket *PacketMS::validateIcPacket(AOClient &client) const
     if (client_name == "") {
         client_name = client.character(); // fallback in case of empty ooc name
     }
-    if (area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING || area->testimonyRecording() == AreaData::TestimonyRecording::ADD) {
+    if ((area->testimonyRecording() == AreaData::TestimonyRecording::RECORDING || area->testimonyRecording() == AreaData::TestimonyRecording::ADD) && !l_args[4].isEmpty()) {
         // -1 indicates title
         if (area->statement() == -1) {
             l_args[4] = "~~-- " + l_args[4] + " --";


### PR DESCRIPTION
Allows for clean recording of paired testimony when one character simply updates animation for every statement (i.e. mood matrix)

Also prevents accidental blankposts from being recorded in the annals of history