### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+### 
+### Build
+###
+FROM ubuntu:noble@sha256:9cbed754112939e914291337b5e554b07ad7c392491dba6daf25eef1332a22e8
+
+# Install build dependencies
+RUN apt-get update && apt-get install build-essential qtbase5-dev qt5-qmake qttools5-dev qttools5-dev-tools libqt5websockets5-dev -y
+
+# Copy files into image
+RUN mkdir /build
+COPY . /build
+
+# Build akashi
+WORKDIR /build
+RUN qmake project-akashi.pro && make -j$(nproc)
+
+### 
+### Run
+###
+FROM ubuntu:noble@sha256:9cbed754112939e914291337b5e554b07ad7c392491dba6daf25eef1332a22e8
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install libqt5websockets5-dev -y
+
+# Copy built assets
+RUN mkdir /app
+COPY --from=0 /build/bin /app
+COPY ./docker-entrypoint.sh /app
+
+# Run akashi
+WORKDIR /app
+ENTRYPOINT [ "bash" ]
+CMD ["-c", "./docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+name: akashi-ace-attorney
+
+services:
+  akashi:
+    build:
+      dockerfile: ./Dockerfile
+    ports:
+      - 27016:27016
+    volumes:
+      - ./config:/app/config

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+# If the config folder exists but is empty, then copy the sample config files into it.
+#
+# This allows users to use a Docker bind mount for /app/config without needing to provide initial configuration.
+# https://docs.docker.com/engine/storage/bind-mounts/
+
+if [ -z "$(ls -A '/app/config')" ]; then
+    echo "/app/config is empty. Copying sample config from /app/config_sample..."
+    cp -r /app/config_sample/. /app/config
+fi
+
+# Run akashi
+./akashi


### PR DESCRIPTION
This PR adds a `Dockerfile` and a `docker-compose.yml` for building akashi as a Docker image and running it with [Docker Compose](https://docs.docker.com/compose/).

### Usage
`docker compose up -d`

This will build the image using the Dockerfile, then create a container on port `27016` with a bind mount at `./config`. The config folder will be created automatically if it doesn't exist. If the folder is empty, then the example config files from `config_sample` (generated by the build) will be copied into it on startup. This should allow it to work out of the box on the first startup, then the user can edit the config files and run `docker compose restart` for the changes to take effect.

### Dockerfile

The Dockerfile uses a [multi-stage build](https://docs.docker.com/build/building/multi-stage/) to try and keep the final image as small as possible by excluding any non-essential build dependencies. Right now the final image size is ~1GB, 750MB of which comes from `libqt5websockets5-dev`. If there's a smaller version of this package that includes the websocket libraries for runtime, then that version could be used instead of this dev version.