### PR TITLE
[FIX] Correct ban timestamp display in the Webhook

### DIFF
--- a/src/packet/packet_ma.cpp
+++ b/src/packet/packet_ma.cpp
@@ -98,13 +98,6 @@ void PacketMA::handlePacket(AreaData *area, AOClient &client) const
             subclient->m_socket->close();
         }
 
-        if (ban.duration == -2) {
-            timestamp = "permanently";
-        }
-        else {
-            timestamp = QString::number(ban.time + ban.duration);
-        }
-
         Q_EMIT client.logBan(moderator_name, target->m_ipid, timestamp, reason);
 
         client.sendServerMessage("Banned " + QString::number(clients.size()) + " client(s) with ipid " + target->m_ipid + " for reason: " + reason);


### PR DESCRIPTION
Remove duplicate code that caused the MA packet to display the Unix timestamp in the Webhook

Before and after :
<img width="393" height="396" alt="image" src="https://github.com/user-attachments/assets/279f6922-3768-4905-9b24-0ed423cee735" />
