### PR TITLE
Add BOM to logfiles

### DIFF
--- a/src/logger/writer_full.cpp
+++ b/src/logger/writer_full.cpp
@@ -32,6 +32,7 @@ void WriterFull::flush(const QString f_entry)
 
     if (l_logfile.open(QIODevice::WriteOnly | QIODevice::Append)) {
         QTextStream file_stream(&l_logfile);
+        file_stream.setGenerateByteOrderMark(true);
         file_stream << f_entry;
     }
     l_logfile.close();
@@ -43,6 +44,7 @@ void WriterFull::flush(const QString f_entry, const QString f_area_name)
 
     if (l_logfile.open(QIODevice::WriteOnly | QIODevice::Append)) {
         QTextStream file_stream(&l_logfile);
+        file_stream.setGenerateByteOrderMark(true);
         file_stream << f_entry;
     }
     l_logfile.close();

--- a/src/logger/writer_modcall.cpp
+++ b/src/logger/writer_modcall.cpp
@@ -37,6 +37,7 @@ void WriterModcall::flush(const QString f_area_name, QQueue<QString> f_buffer)
 
     if (l_logfile.open(QIODevice::WriteOnly | QIODevice::Append)) {
         QTextStream file_stream(&l_logfile);
+        file_stream.setGenerateByteOrderMark(true);
 
         while (!f_buffer.isEmpty())
             file_stream << f_buffer.dequeue();


### PR DESCRIPTION
Some editors (Excel, WinSCPs preview) don't parse UTF-8 by default unless a BOM is present.