### PR TITLE
Move PR/PU register step to RD packet

### DIFF
--- a/src/packet/packet_rd.cpp
+++ b/src/packet/packet_rd.cpp
@@ -63,5 +63,6 @@ void PacketRD::handlePacket(AreaData *area, AOClient &client) const
     }
     emit client.joined();
     area->addClient(-1, client.clientId());
+    client.getServer()->getPlayerStateObserver()->registerClient(&client);
     client.arup(client.ARUPType::PLAYER_COUNT, true); // Tell everyone there is a new player
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -153,7 +153,6 @@ void Server::clientConnected()
     int user_id = m_available_ids.pop();
     AOClient *client = new AOClient(this, l_socket, l_socket, user_id, music_manager);
     m_clients_ids.insert(user_id, client);
-    m_player_state_observer.registerClient(client);
 
     int multiclient_count = 1;
     bool is_at_multiclient_limit = false;
@@ -275,6 +274,11 @@ QHostAddress Server::parseToIPv4(QHostAddress f_remote_ip)
         l_remote_ip = l_temp_remote_ip;
     }
     return l_remote_ip;
+}
+
+PlayerStateObserver *Server::getPlayerStateObserver()
+{
+    return &m_player_state_observer;
 }
 
 void Server::reloadSettings()

--- a/src/server.h
+++ b/src/server.h
@@ -336,6 +336,11 @@ class Server : public QObject
      */
     QHostAddress parseToIPv4(QHostAddress f_remote_ip);
 
+    /**
+     * @brief Returns a raw-pointer of the curr
+     */
+    PlayerStateObserver *getPlayerStateObserver();
+
   public slots:
     /**
      * @brief Convenience class to call a reload of available configuraiton elements.


### PR DESCRIPTION
Under complaint of Omni that this step preceeds the ASS packet and thus makes loading that media a pain in the ass for WebAO it was moved here.

Should it be in a better place? Yes.
Am I paid enough to code that place today? No.