### PR TITLE
Adjust AreaKickCMD

### DIFF
--- a/src/area_data.cpp
+++ b/src/area_data.cpp
@@ -46,6 +46,10 @@ AreaData::AreaData(QString p_name, int p_index, MusicManager *p_music_manager = 
     QStringList name_split = p_name.split(":");
     name_split.removeFirst();
     m_name = name_split.join(":");
+    if (m_name.isEmpty()) {
+        m_name = "Unnamed Area";
+    }
+    m_display_name = "[" + QString::number(m_index) + "] " + m_name;
     QSettings *areas_ini = ConfigManager::areaData();
     areas_ini->beginGroup(p_name);
     m_background = areas_ini->value("background", "gs4").toString();
@@ -228,6 +232,11 @@ QString AreaData::name() const
 int AreaData::index() const
 {
     return m_index;
+}
+
+QString AreaData::displayName() const
+{
+    return m_display_name;
 }
 
 QList<int> AreaData::charactersTaken() const

--- a/src/area_data.h
+++ b/src/area_data.h
@@ -389,6 +389,13 @@ class AreaData : public QObject
     int index() const;
 
     /**
+     * @brief Returns the display name of the area.
+     *
+     * @return See short description.
+     */
+    QString displayName() const;
+
+    /**
      * @brief Returns a copy of the list of characters taken.
      *
      * @return A list of character IDs.
@@ -1047,6 +1054,11 @@ class AreaData : public QObject
      * @brief The index of the area in the server's area list.
      */
     int m_index;
+
+    /**
+     * @brief The display name of the area.
+     */
+    QString m_display_name;
 
     /**
      * @brief Pointer to the global music manager.

--- a/src/commands/area.cpp
+++ b/src/commands/area.cpp
@@ -260,10 +260,41 @@ void AOClient::cmdArea(int argc, QStringList argv)
 
 void AOClient::cmdAreaKick(int argc, QStringList argv)
 {
-    Q_UNUSED(argc);
-
     AreaData *l_area = server->getAreaById(areaId());
 
+    int target_area = 0; // Default to first area of the server
+
+    // Check if a target area is provided
+    if (argc >= 2) {
+        if (!checkPermission(ACLRole::KICK)) {
+            sendServerMessage("You do not have permission to kick to specific areas. Just the first area as CM. (/areakick [ID]).");
+            return;
+        }
+
+        bool ok;
+        target_area = argv[1].toInt(&ok);
+        if (!ok || target_area < 0 || target_area >= server->getAreaCount()) {
+            sendServerMessage("That does not look like a valid area ID.");
+            return;
+        }
+    }
+
+    if (argv[0] == "all") {
+        const QVector<AOClient *> l_clients = server->getClients();
+        for (AOClient *l_client : l_clients) {
+            if (l_client->areaId() == areaId() && l_client->clientId() != clientId()) {
+                if (!server->getAreaById(areaId())->owners().contains(l_client->clientId())) {
+                    l_client->changeArea(target_area);
+                    l_area->uninvite(l_client->clientId());
+                    l_client->sendServerMessage("You have been kicked to area " + QString::number(target_area) + ".");
+                }
+            }
+        }
+        sendServerMessage("All clients kicked to area " + QString::number(target_area) + ".");
+        return;
+    }
+
+    // Without secondary area argument
     bool ok;
     int l_idx = argv[0].toInt(&ok);
     if (!ok) {
@@ -283,10 +314,10 @@ void AOClient::cmdAreaKick(int argc, QStringList argv)
         sendServerMessage("That client is not in this area.");
         return;
     }
-    l_client_to_kick->changeArea(0);
+    l_client_to_kick->changeArea(target_area);
     l_area->uninvite(l_client_to_kick->clientId());
-
-    sendServerMessage("Client " + argv[0] + " kicked back to area 0.");
+    l_client_to_kick->sendServerMessage("You have been kicked to area " + QString::number(target_area) + ".");
+    sendServerMessage("Client " + argv[0] + " kicked to area " + QString::number(target_area) + ".");
 }
 
 void AOClient::cmdSetBackground(int argc, QStringList argv)

--- a/src/commands/area.cpp
+++ b/src/commands/area.cpp
@@ -262,7 +262,7 @@ void AOClient::cmdAreaKick(int argc, QStringList argv)
 {
     AreaData *l_area = server->getAreaById(areaId());
 
-    int target_area = 0; // Default to first area of the server
+    int target_area_id = 0; // Default to first area of the server
 
     // Check if a target area is provided
     if (argc >= 2) {
@@ -272,25 +272,27 @@ void AOClient::cmdAreaKick(int argc, QStringList argv)
         }
 
         bool ok;
-        target_area = argv[1].toInt(&ok);
-        if (!ok || target_area < 0 || target_area >= server->getAreaCount()) {
+        target_area_id = argv[1].toInt(&ok);
+        if (!ok || target_area_id < 0 || target_area_id >= server->getAreaCount()) {
             sendServerMessage("That does not look like a valid area ID.");
             return;
         }
     }
+
+    AreaData *target_area = server->getAreaById(target_area_id);
 
     if (argv[0] == "all") {
         const QVector<AOClient *> l_clients = server->getClients();
         for (AOClient *l_client : l_clients) {
             if (l_client->areaId() == areaId() && l_client->clientId() != clientId()) {
                 if (!server->getAreaById(areaId())->owners().contains(l_client->clientId())) {
-                    l_client->changeArea(target_area);
+                    l_client->changeArea(target_area_id);
                     l_area->uninvite(l_client->clientId());
-                    l_client->sendServerMessage("You have been kicked to area " + QString::number(target_area) + ".");
+                    l_client->sendServerMessage("You have been kicked to area " + target_area->displayName() + ".");
                 }
             }
         }
-        sendServerMessage("All clients kicked to area " + QString::number(target_area) + ".");
+        sendServerMessage("All clients kicked to area " + target_area->displayName() + ".");
         return;
     }
 
@@ -314,10 +316,10 @@ void AOClient::cmdAreaKick(int argc, QStringList argv)
         sendServerMessage("That client is not in this area.");
         return;
     }
-    l_client_to_kick->changeArea(target_area);
+    l_client_to_kick->changeArea(target_area_id);
     l_area->uninvite(l_client_to_kick->clientId());
-    l_client_to_kick->sendServerMessage("You have been kicked to area " + QString::number(target_area) + ".");
-    sendServerMessage("Client " + argv[0] + " kicked to area " + QString::number(target_area) + ".");
+    l_client_to_kick->sendServerMessage("You have been kicked to area " + target_area->displayName() + ".");
+    sendServerMessage("Client " + argv[0] + " kicked to area " + target_area->displayName() + ".");
 }
 
 void AOClient::cmdSetBackground(int argc, QStringList argv)
@@ -504,8 +506,10 @@ void AOClient::cmdClearAreaMessage(int argc, QStringList argv)
 
     AreaData *l_area = server->getAreaById(areaId());
     l_area->clearAreaMessage();
-    if (l_area->sendAreaMessageOnJoin())              // Turn off the automatic sending.
+    if (l_area->sendAreaMessageOnJoin()) // Turn off the automatic sending.
+    {
         cmdToggleAreaMessageOnJoin(0, QStringList{}); // Dummy values.
+    }
 }
 
 void AOClient::cmdWebfiles(int argc, QStringList argv)


### PR DESCRIPTION
Allows KICK permission holders to kick people to a specific area, instead of just area 0.

Allows KICK permission users to kick everyone at once to one place, instead of one by one.

Likely a better way to sanitize area input, or the output check. Input on this is welcome.