### PR TITLE
Fix seg fault when /roll is called with leading +/- . Typing /roll +d6 or -6 causes segfault. Command not gated by any permission. 

### DIFF
--- a/src/commands/roleplay.cpp
+++ b/src/commands/roleplay.cpp
@@ -54,6 +54,10 @@ void AOClient::cmdRoll(int argc, QStringList argv)
             if (argv[0].contains('+')) {
                 bool l_mod_ok;
                 QStringList l_modifier = l_arguments[1].split('+');
+                if (l_modifier.size() < 2) {
+                    sendServerMessage("Invalid dice notation.");
+                    return;
+                }
                 int modifier = l_modifier[1].toInt(&l_mod_ok);
                 l_sides = l_modifier[0].toInt(&l_sides_ok);
 
@@ -66,6 +70,10 @@ void AOClient::cmdRoll(int argc, QStringList argv)
             else if (argv[0].contains('-')) {
                 bool l_mod_ok;
                 QStringList l_modifier = l_arguments[1].split('-');
+                if (l_modifier.size() < 2) {
+                    sendServerMessage("Invalid dice notation.");
+                    return;
+                }
                 int modifier = l_modifier[1].toInt(&l_mod_ok);
                 l_sides = l_modifier[0].toInt(&l_sides_ok);
 
@@ -128,6 +136,10 @@ void AOClient::cmdRollP(int argc, QStringList argv)
             if (argv[0].contains('+')) {
                 bool l_mod_ok;
                 QStringList l_modifier = l_arguments[1].split('+');
+                if (l_modifier.size() < 2) {
+                    sendServerMessage("Invalid dice notation.");
+                    return;
+                }
                 int modifier = l_modifier[1].toInt(&l_mod_ok);
                 l_sides = l_modifier[0].toInt(&l_sides_ok);
 
@@ -140,6 +152,10 @@ void AOClient::cmdRollP(int argc, QStringList argv)
             else if (argv[0].contains('-')) {
                 bool l_mod_ok;
                 QStringList l_modifier = l_arguments[1].split('-');
+                if (l_modifier.size() < 2) {
+                    sendServerMessage("Invalid dice notation.");
+                    return;
+                }
                 int modifier = l_modifier[1].toInt(&l_mod_ok);
                 l_sides = l_modifier[0].toInt(&l_sides_ok);
 


### PR DESCRIPTION
 When /roll +d6 or /roll -d6 is typed, argv[0].split('d') produces ["+", "6"], and then splitting "6" on '+' yields
  only one element. The original code unconditionally accessed index [1] of that result, which is out-of-bounds and
  causes a segfault. The fix adds a size() < 2 guard before that access, returning "Invalid dice notation." instead of
  crashing.                                                                                                             