### PR TITLE
Release QNetworkReply after handling masterserver response

### DIFF
--- a/src/serverpublisher.cpp
+++ b/src/serverpublisher.cpp
@@ -77,6 +77,7 @@ void ServerPublisher::publishServer()
 void ServerPublisher::finished(QNetworkReply *f_reply)
 {
     QNetworkReply *reply(f_reply);
+    reply->deleteLater();
     QString remote_url = reply->url().toString();
 
     if (reply->error() != QNetworkReply::NoError) {


### PR DESCRIPTION
What the patch does: Adds reply->deleteLater(); so each QNetworkReply is freed after finished() runs instead of leaking until process exit.

Effect: Stops the slow accumulation of dead reply objects (~360/day at the 4-min cadence) and lets Qt actually tear down the HTTP/2 stream state for each completed request, matching how every other reply handler in the codebase (e.g. Discord::onReplyFinished) already behaves.

Risk: None — deleteLater() defers the delete to the event loop, so reply stays valid through the rest of the function. Logging and publish cadence are unchanged.