### PR TITLE
Fuck HTTP/2 in favour of HTTP 1.1  "Connection closed" / qt.network.http2: stream 1 finished with error: "Connection closed" Fix. 

### DIFF
--- a/src/serverpublisher.cpp
+++ b/src/serverpublisher.cpp
@@ -53,6 +53,7 @@ void ServerPublisher::publishServer()
     if (serverlist.isValid()) {
         QNetworkRequest request(serverlist);
         request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+        request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
 
         QJsonObject serverinfo;
         if (!ConfigManager::serverDomainName().trimmed().isEmpty()) {

--- a/src/serverpublisher.cpp
+++ b/src/serverpublisher.cpp
@@ -77,6 +77,7 @@ void ServerPublisher::publishServer()
 void ServerPublisher::finished(QNetworkReply *f_reply)
 {
     QNetworkReply *reply(f_reply);
+    reply->deleteLater();
     QString remote_url = reply->url().toString();
 
     if (reply->error() != QNetworkReply::NoError) {


### PR DESCRIPTION
I was not able to find the EXACT bug with QT's HTTP/2 implementation however I was able to figure out that it has something to do with HTTP/2.

 "Connection closed" / qt.network.http2: stream 1 finished with error: "Connection closed"

This would anywhere from a few minutes to 40+ minutes before recovering on its own with no config change, restart, or network event on the akashi side. As seen in my first Akashi log named Akashi log 1 with no logging involved pure error message.

Akashi Log 1 with the error  "Connection closed" / qt.network.http2: stream 1 finished with error: "Connection closed"

[Akashi log 1 Master Server using QT HTTP 2 errors.txt](https://github.com/user-attachments/files/28153345/Akashi.log.1.Master.Server.using.QT.HTTP.2.errors.txt)

I then decided to attach a logger to rule out the payload being the root cause of this issue. So I logged the exact bytes of every POST it sends, right next to the existing "Advertising to masterserver" / "Unable to connect" log lines. In my second log provided named 

**Akashi log 2** 
[akashi log 2 logging entire payload request using qt http 2 implementation.txt](https://github.com/user-attachments/files/28153372/akashi.log.2.logging.entire.payload.request.using.qt.http.2.implementation.txt)

**May 21 10:00:04 vps-4b2f75ec akashi[206189]: Unable to connect to serverlist due to the following error: "Connection closed"
May 21 10:00:04 vps-4b2f75ec akashi[206189]: Remote URL: "https://servers.aceattorneyonline.com/servers"**

As you can see in the second log there was nothing wrong with the payload the server was sending. So then I thought what if we changed from HTTP 2 to HTTP 1.1 for the server publisher. I also changed the advertiser to one minute to gather more samples during a bad period but kept it on four minutes in this commit like upstream intended.

The results with changing from HTTP 2 to HTTP 1.1 was a stark difference. Since then I have had no more issues advertising to master. So it was not a VPS config, anti DDOS, it was known documented issues with QT's HTTP/2 implementation.  Here is the complete log for advertising via HTTP 1.1 named Akashi 3

Akashi 3 log)
[akashi log 3 with entire payload logging using qt http 1.1 no errors for the first time.log](https://github.com/user-attachments/files/28153589/akashi.log.3.with.entire.payload.logging.using.qt.http.1.1.no.errors.for.the.first.time.log)


I do not have enough time to figure out the EXACT bug lol but I do know HTTP/2 is the root cause of the connection failing at random times from 5 minutes to up to 45 minutes therefore dropping some akashi servers from master.

Some potential clues:
QTBUG-73947 - HTTP2 streams terminated prematurely on GOAWAY

https://bugreports.qt.io/browse/QTBUG-73947

Why we should swap to HTTP 1.1
--------------
Beyond being a easy to implement bug fix.  HTTP/1.1 is also the more appropriate protocol for this call as each advertise is only a tiny small post with no parallel requests on the connection so all of the benefits that even come from HTTP/2 are nothing for this use case whatsoever. 

The cost of an extra TLS handshake every few minutes is minimal, and in exchange we get a stateless, connection-per-request flow that's immune the failures of the HTTP/2 implementation introduced here.

The patch is a one line fix and will also stop people complaining about Akashi/MS dropping their connection as HTTP/2 is the obvious culprit here even if I don't know the exact root cause that much is proven from this test with full debug logging.  This also works on every QT version Akashi supports.








