### PR TITLE
Update clang-format version to 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run clang-format style check.
       uses: jidicula/clang-format-action@v4.5.0
       with:
-        clang-format-version: '14'
+        clang-format-version: '16'
         check-path: '.'
         
   build-linux:


### PR DESCRIPTION
Version 16 was what was bundled with the Qt setup during 6.5.3 release (which is what akashi is based on right now)